### PR TITLE
Use string instead of symbol

### DIFF
--- a/0rsk.rb
+++ b/0rsk.rb
@@ -227,7 +227,7 @@ end
 
 def current_user
   redirect '/' unless @locals[:user]
-  @locals[:user][:id].downcase
+  @locals[:user]['id'].downcase
 end
 
 def current_project


### PR DESCRIPTION
This problem could have been avoided if we had returned a `User` instance instead.

In fact, there is something wrong
with the design here: The name of the method is `current_user`, but it returns lowercased id for some reason. 

Fixes #138