### PR TITLE
Do not print info level debug messages from `raven` gem in test env

### DIFF
--- a/0rsk.rb
+++ b/0rsk.rb
@@ -38,12 +38,12 @@ configure do
     'sentry' => ''
   }
   config = YAML.safe_load(File.open(File.join(File.dirname(__FILE__), 'config.yml'))) unless ENV['RACK_ENV'] == 'test'
-  if ENV['RACK_ENV'] != 'test'
-    Sentry.init do |c|
-      c.dsn = config['sentry']
-      c.release = Rsk::VERSION
-    end
+
+  Sentry.init do |c|
+    c.dsn = config['sentry']
+    c.release = Rsk::VERSION
   end
+
   set :bind, '0.0.0.0'
   set :server, :thin
   set :show_exceptions, false

--- a/0rsk.rb
+++ b/0rsk.rb
@@ -38,12 +38,10 @@ configure do
     'sentry' => ''
   }
   config = YAML.safe_load(File.open(File.join(File.dirname(__FILE__), 'config.yml'))) unless ENV['RACK_ENV'] == 'test'
-
   Sentry.init do |c|
     c.dsn = config['sentry']
     c.release = Rsk::VERSION
   end
-
   set :bind, '0.0.0.0'
   set :server, :thin
   set :show_exceptions, false

--- a/test/test__helper.rb
+++ b/test/test__helper.rb
@@ -34,6 +34,11 @@ Minitest::Reporters.use! [Minitest::Reporters::SpecReporter.new]
 require 'loog'
 require 'pgtk/pool'
 require 'yaml'
+require 'sentry-ruby'
+
+Sentry.init do |config|
+  config.logger.level = Logger::WARN
+end
 
 class Minitest::Test
   def test_pgsql


### PR DESCRIPTION
Do not print `info` level debug messages from `raven` gem.
```
I, [2025-05-24T06:59:30.425311 #6626]  INFO -- sentry: **
 [Raven] Raven 3.1.2 configured not to capture errors: DSN not set
I, [2025-05-24T06:59:30.716045 #6626]  INFO -- sentry: ** [Raven]
Raven 3.1.2 configured not to capture errors: No host specified,
no public_key specified, no project_id specified
```