### PR TITLE
Truncate all db tables in a teardown phase

### DIFF
--- a/test/test__helper.rb
+++ b/test/test__helper.rb
@@ -36,6 +36,10 @@ require 'pgtk/pool'
 require 'yaml'
 
 class Minitest::Test
+  def teardown
+    truncate_all_db_tables
+  end
+
   def test_pgsql
     # rubocop:disable Style/ClassVars
     @@test_pgsql ||= Pgtk::Pool.new(
@@ -43,5 +47,26 @@ class Minitest::Test
       log: Loog::NULL
     ).start
     # rubocop:enable Style/ClassVars
+  end
+
+  private
+
+  def truncate_all_db_tables
+    test_pgsql.exec <<-SQL
+      -- Disable "truncate cascades to table" notice
+      set client_min_messages = warning;
+
+      DO $$
+      DECLARE
+          table_name TEXT;
+      BEGIN
+          FOR table_name IN SELECT tablename FROM pg_tables WHERE schemaname = 'public' LOOP
+              EXECUTE 'TRUNCATE TABLE ' || table_name || ' CASCADE';
+          END LOOP;
+      END $$;
+
+      -- Reset
+      set client_min_messages = notice;
+    SQL
   end
 end

--- a/test/test__helper.rb
+++ b/test/test__helper.rb
@@ -61,7 +61,7 @@ class Minitest::Test
           table_name TEXT;
       BEGIN
           FOR table_name IN SELECT tablename FROM pg_tables WHERE schemaname = 'public' LOOP
-              EXECUTE 'TRUNCATE TABLE ' || table_name || ' CASCADE';
+              EXECUTE 'TRUNCATE TABLE ' || table_name || ' RESTART IDENTITY CASCADE';
           END LOOP;
       END $$;
 


### PR DESCRIPTION
https://github.com/yegor256/0rsk/pull/165#issuecomment-2916625626

I still think this PR is needed and ready to discuss it. I have been bitten many times when I forgot to clean up, so I think cleaning up "globally" is worth it as a countermeasure.

The time spent on debugging sporadic errors caused by the lack of db cleanup is enormous.