### PR TITLE
#266: fail cleanly on missing telechat rows

### DIFF
--- a/objects/telechats.rb
+++ b/objects/telechats.rb
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: MIT
 
 require_relative 'rsk'
+require_relative 'urror'
 
 # Telechats.
 # Author:: Yegor Bugayenko (yegor256@gmail.com)
@@ -30,11 +31,15 @@ class Rsk::Telechats
   end
 
   def login_of(id)
-    @pgsql.exec('SELECT login FROM telechat WHERE id = $1', [id])[0]['login']
+    row = @pgsql.exec('SELECT login FROM telechat WHERE id = $1', [id])[0]
+    raise Rsk::Urror, "Telegram chat ##{id} not found" if row.nil?
+    row['login']
   end
 
   def chat_of(login)
-    @pgsql.exec('SELECT id FROM telechat WHERE login = $1', [login])[0]['id'].to_i
+    row = @pgsql.exec('SELECT id FROM telechat WHERE login = $1', [login])[0]
+    raise Rsk::Urror, "Telegram login #{login.inspect} not found" if row.nil?
+    row['id'].to_i
   end
 
   # This message was just posted.
@@ -44,6 +49,8 @@ class Rsk::Telechats
 
   # This message is different from the last posted?
   def diff?(msg, chat)
-    @pgsql.exec('SELECT recent FROM telechat WHERE id = $1', [chat])[0]['recent'] != msg
+    row = @pgsql.exec('SELECT recent FROM telechat WHERE id = $1', [chat])[0]
+    raise Rsk::Urror, "Telegram chat ##{chat} not found" if row.nil?
+    row['recent'] != msg
   end
 end

--- a/test/test_telechats.rb
+++ b/test/test_telechats.rb
@@ -5,12 +5,31 @@
 
 require_relative 'test__helper'
 require_relative '../objects/telechats'
+require_relative '../objects/urror'
 
 # Test of Telechats.
 # Author:: Yegor Bugayenko (yegor256@gmail.com)
 # Copyright:: Copyright (c) 2019-2026 Yegor Bugayenko
 # License:: MIT
 class Rsk::TelechatsTest < Minitest::Test
+  def test_fails_cleanly_when_chat_login_is_absent
+    assert_raises(Rsk::Urror) do
+      Rsk::Telechats.new(FakeTelechatsPgsql.new).login_of(rand(99_999))
+    end
+  end
+
+  def test_fails_cleanly_when_chat_id_is_absent
+    assert_raises(Rsk::Urror) do
+      Rsk::Telechats.new(FakeTelechatsPgsql.new).chat_of("judy#{rand(99_999)}")
+    end
+  end
+
+  def test_fails_cleanly_when_recent_message_is_absent
+    assert_raises(Rsk::Urror) do
+      Rsk::Telechats.new(FakeTelechatsPgsql.new).diff?('hello', rand(99_999))
+    end
+  end
+
   def test_checks
     login = "judy#{rand(99_999)}"
     telechats = Rsk::Telechats.new(test_pgsql)
@@ -20,5 +39,12 @@ class Rsk::TelechatsTest < Minitest::Test
     telechats.posted(msg, chat)
     refute(telechats.diff?(msg, chat))
     assert(telechats.diff?('something else', chat))
+  end
+
+  # Fake PostgreSQL handle that simulates a SELECT returning no rows.
+  class FakeTelechatsPgsql
+    def exec(_query, _params)
+      []
+    end
   end
 end


### PR DESCRIPTION
﻿Fixes #266.

This keeps `Rsk::Telechats` from surfacing raw `NoMethodError` when a single-row `telechat` lookup returns no rows. `login_of`, `chat_of`, and `diff?` now check the SELECT result before indexing it and raise `Rsk::Urror` with a deterministic message instead.

Validation:
- RED before implementation: `ruby -Itest test\test_telechats.rb -n "/absent/"` failed 3 tests with `NoMethodError` instead of `Rsk::Urror`.
- GREEN: `$env:PICKS='1'; ruby -Itest test\test_telechats.rb -n "/absent/"` -> 3 tests, 3 assertions, 0 failures, 0 errors.
- `ruby -c objects\telechats.rb; ruby -c test\test_telechats.rb` -> Syntax OK for both files.
- `rubocop objects\telechats.rb test\test_telechats.rb --format simple` -> 2 files inspected, no offenses detected.
- `git diff --check` -> clean.
- `git diff -- objects\telechats.rb test\test_telechats.rb | gitleaks stdin --no-banner --redact --exit-code 1 --log-level info` -> no leaks found.

Limits:
- Full `bundle install` is not claimed on this Windows machine because native `openssl` and `psych` builds fail without OpenSSL/libyaml headers.
- Full `test\test_telechats.rb` is not claimed because the integration test needs `target/pgsql-config.yml`; `rake pgsql liquibase` failed locally with `ArgumentError: unknown keyword: :log` in the pgtk task path.
