### PR TITLE
#268: submit destructive actions via POST

### DIFF
--- a/0rsk.rb
+++ b/0rsk.rb
@@ -94,7 +94,7 @@ get '/ranked' do
   )
 end
 
-get '/ranked/delete' do
+post '/ranked/delete' do
   id = params[:id]
   triples.delete(id)
   flash('/ranked', "The ranked triple ##{id} deleted")
@@ -119,7 +119,7 @@ post '/projects/create' do
   flash("/projects/select?id=#{pid}", "A new project ##{pid} selected")
 end
 
-get '/projects/delete' do
+post '/projects/delete' do
   pid = params[:id]
   projects.delete(pid)
   flash('/projects', "The project ##{pid} has been deleted")
@@ -153,7 +153,7 @@ post '/responses/add' do
   flash("/responses?id=#{id}", "Thanks, plan ##{pid}/#{part} added to the triple ##{id}")
 end
 
-get '/responses/detach' do
+post '/responses/detach' do
   tid = params[:tid].to_i
   id = params[:id].to_i
   part = params[:part].to_i

--- a/test/test_destructive_routes.rb
+++ b/test/test_destructive_routes.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+ENV['RACK_ENV'] = 'test'
+
+require 'minitest/autorun'
+require_relative '../objects/rsk'
+
+class Rsk::DestructiveRoutesTest < Minitest::Test
+  def test_destructive_actions_are_not_get_routes
+    refute_match(%r{^get '/projects/delete'}m, app)
+    refute_match(%r{^get '/ranked/delete'}m, app)
+    refute_match(%r{^get '/responses/detach'}m, app)
+  end
+
+  def test_destructive_actions_are_post_routes
+    assert_match(%r{^post '/projects/delete'}m, app)
+    assert_match(%r{^post '/ranked/delete'}m, app)
+    assert_match(%r{^post '/responses/detach'}m, app)
+  end
+
+  def test_destructive_controls_use_post_forms
+    controls = {
+      'views/projects.haml' => '/projects/delete',
+      'views/ranked.haml' => '/ranked/delete',
+      'views/responses.haml' => '/responses/detach'
+    }
+    controls.each do |file, path|
+      view = File.read(file)
+      assert_match(
+        /%form\{[^}]*method: 'POST'[^}]*action: iri\.cut\('#{Regexp.escape(path)}'\)/,
+        view
+      )
+      refute_match(/%a\.item.*href: iri\.cut\('#{Regexp.escape(path)}'\)/, view)
+    end
+  end
+
+  private
+
+  def app
+    File.read('0rsk.rb')
+  end
+end

--- a/views/projects.haml
+++ b/views/projects.haml
@@ -23,4 +23,6 @@
         &= p[:title]
       %br
       %span.small
-        %a.item{href: iri.cut('/projects/delete').add(id: p[:id]), onclick: "return confirm('Are sure you want to delete it?');"} Delete
+        %form{method: 'POST', action: iri.cut('/projects/delete'), onsubmit: "return confirm('Are sure you want to delete it?');", style: 'display: inline;'}
+          %input{type: 'hidden', name: 'id', value: p[:id]}
+          %input.item{type: 'submit', value: 'Delete'}

--- a/views/ranked.haml
+++ b/views/ranked.haml
@@ -45,7 +45,9 @@
         - else
           = "#{r[:plans].count} plan#{r[:plans].count == 1 ? '' : 's'}"
           = '&darr;'
-      %a.item.small{href: iri.cut('/ranked/delete').add(id: r[:id]), onclick: "return confirm('Are sure you want to delete triple ##{r[:id]}');"} Delete
+      %form{method: 'POST', action: iri.cut('/ranked/delete'), onsubmit: "return confirm('Are sure you want to delete triple ##{r[:id]}');", style: 'display: inline;'}
+        %input{type: 'hidden', name: 'id', value: r[:id]}
+        %input.item.small{type: 'submit', value: 'Delete'}
       - unless r[:plans].empty?
         - r[:plans].each do |p|
           %br

--- a/views/responses.haml
+++ b/views/responses.haml
@@ -78,7 +78,11 @@
     %br
     %span.item.small
       &= p[:schedule]
-    %a.item.small{href: iri.cut('/responses/detach').add(tid: triple[:id], id: p[:id], part: p[:part]), onclick: "return confirm('Are sure you want to detach plan ##{p[:id]}');"} Detach
+    %form{method: 'POST', action: iri.cut('/responses/detach'), onsubmit: "return confirm('Are sure you want to detach plan ##{p[:id]}');", style: 'display: inline;'}
+      %input{type: 'hidden', name: 'tid', value: triple[:id]}
+      %input{type: 'hidden', name: 'id', value: p[:id]}
+      %input{type: 'hidden', name: 'part', value: p[:part]}
+      %input.item.small{type: 'submit', value: 'Detach'}
 
 %p
   If you are in doubt and need to learn more about


### PR DESCRIPTION
Fixes #268.

Changes:
- switch `/projects/delete`, `/ranked/delete`, and `/responses/detach` from `GET` to `POST`
- replace the destructive HAML links with inline POST forms that preserve the existing confirmation prompts and parameters
- add focused tests that guard the route declarations and destructive controls

Validation:
- RED: `ruby -Itest test\test_destructive_routes.rb` failed before the fix because the routes were GET-only and the controls were links
- GREEN: `$env:PICKS='1'; ruby -Itest test\test_destructive_routes.rb` passed: 3 runs, 24 assertions
- `ruby -c 0rsk.rb`
- `ruby -c test\test_destructive_routes.rb`
- `ruby -e "require 'haml'; ARGV.each { |f| Haml::Engine.new(File.read(f)); puts f }" views\projects.haml views\ranked.haml views\responses.haml`
- `rubocop 0rsk.rb test\test_destructive_routes.rb --format simple`
- `git diff --check`
- staged `git diff --check`
- diff-only gitleaks scan

Limitation: I did not run the DB-backed full suite locally. `rake pgsql liquibase` currently fails in this Windows checkout with `ArgumentError: unknown keyword: :log` from the local `pgtk` task path before `target/pgsql-config.yml` is generated.