### PR TITLE
#263: reject triple part ids from another project

### DIFF
--- a/objects/causes.rb
+++ b/objects/causes.rb
@@ -6,6 +6,7 @@
 require_relative 'rsk'
 require_relative 'cause'
 require_relative 'query'
+require_relative 'urror'
 
 # Causes.
 # Author:: Yegor Bugayenko (yegor256@gmail.com)
@@ -42,6 +43,15 @@ class Rsk::Causes
 
   def get(id)
     require_relative 'cause'
+    found = @pgsql.exec(
+      [
+        'SELECT cause.id FROM cause',
+        'JOIN part ON part.id = cause.id',
+        'WHERE cause.id = $1 AND part.project = $2'
+      ],
+      [id, @project]
+    )
+    raise Rsk::Urror, "Cause ##{id} not found in project ##{@project}" if found.empty?
     Rsk::Cause.new(@pgsql, id)
   end
 

--- a/objects/effects.rb
+++ b/objects/effects.rb
@@ -6,6 +6,7 @@
 require_relative 'rsk'
 require_relative 'effect'
 require_relative 'query'
+require_relative 'urror'
 
 # Effects.
 # Author:: Yegor Bugayenko (yegor256@gmail.com)
@@ -30,6 +31,15 @@ class Rsk::Effects
 
   def get(id)
     require_relative 'effect'
+    found = @pgsql.exec(
+      [
+        'SELECT effect.id FROM effect',
+        'JOIN part ON part.id = effect.id',
+        'WHERE effect.id = $1 AND part.project = $2'
+      ],
+      [id, @project]
+    )
+    raise Rsk::Urror, "Effect ##{id} not found in project ##{@project}" if found.empty?
     Rsk::Effect.new(@pgsql, id)
   end
 

--- a/objects/risks.rb
+++ b/objects/risks.rb
@@ -6,6 +6,7 @@
 require_relative 'rsk'
 require_relative 'risk'
 require_relative 'query'
+require_relative 'urror'
 
 # Risks.
 # Author:: Yegor Bugayenko (yegor256@gmail.com)
@@ -30,6 +31,15 @@ class Rsk::Risks
 
   def get(id)
     require_relative 'risk'
+    found = @pgsql.exec(
+      [
+        'SELECT risk.id FROM risk',
+        'JOIN part ON part.id = risk.id',
+        'WHERE risk.id = $1 AND part.project = $2'
+      ],
+      [id, @project]
+    )
+    raise Rsk::Urror, "Risk ##{id} not found in project ##{@project}" if found.empty?
     Rsk::Risk.new(@pgsql, id)
   end
 

--- a/test/test_causes.rb
+++ b/test/test_causes.rb
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: MIT
 
 require_relative 'test__helper'
+require 'securerandom'
 require_relative '../objects/rsk'
 require_relative '../objects/causes'
 require_relative '../objects/projects'
@@ -34,8 +35,8 @@ class Rsk::CausesTest < Minitest::Test
   end
 
   def test_rejects_cause_from_another_project
-    mine = Rsk::Projects.new(test_pgsql, "my#{rand(99_999)}").add("t#{rand(99_999)}")
-    other = Rsk::Projects.new(test_pgsql, "you#{rand(99_999)}").add("t#{rand(99_999)}")
+    mine = Rsk::Projects.new(test_pgsql, "my#{SecureRandom.hex(8)}").add("t#{SecureRandom.hex(8)}")
+    other = Rsk::Projects.new(test_pgsql, "you#{SecureRandom.hex(8)}").add("t#{SecureRandom.hex(8)}")
     cid = Rsk::Causes.new(test_pgsql, other).add('other cause')
     assert_raises(Rsk::Urror) { Rsk::Causes.new(test_pgsql, mine).get(cid) }
   end

--- a/test/test_causes.rb
+++ b/test/test_causes.rb
@@ -32,4 +32,11 @@ class Rsk::CausesTest < Minitest::Test
     causes.get(cid).emoji = '💰'
     assert_operator(causes.emojis.count, :>, 1)
   end
+
+  def test_rejects_cause_from_another_project
+    mine = Rsk::Projects.new(test_pgsql, "my#{rand(99_999)}").add("t#{rand(99_999)}")
+    other = Rsk::Projects.new(test_pgsql, "you#{rand(99_999)}").add("t#{rand(99_999)}")
+    cid = Rsk::Causes.new(test_pgsql, other).add('other cause')
+    assert_raises(Rsk::Urror) { Rsk::Causes.new(test_pgsql, mine).get(cid) }
+  end
 end

--- a/test/test_effects.rb
+++ b/test/test_effects.rb
@@ -22,4 +22,11 @@ class Rsk::EffectsTest < Minitest::Test
     assert_equal(1, effects.count)
     assert(effects.fetch.any? { |c| c[:text] == text })
   end
+
+  def test_rejects_effect_from_another_project
+    mine = Rsk::Projects.new(test_pgsql, "my#{rand(99_999)}").add("t#{rand(99_999)}")
+    other = Rsk::Projects.new(test_pgsql, "you#{rand(99_999)}").add("t#{rand(99_999)}")
+    eid = Rsk::Effects.new(test_pgsql, other).add('other effect')
+    assert_raises(Rsk::Urror) { Rsk::Effects.new(test_pgsql, mine).get(eid) }
+  end
 end

--- a/test/test_effects.rb
+++ b/test/test_effects.rb
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: MIT
 
 require_relative 'test__helper'
+require 'securerandom'
 require_relative '../objects/rsk'
 require_relative '../objects/effects'
 require_relative '../objects/projects'
@@ -24,8 +25,8 @@ class Rsk::EffectsTest < Minitest::Test
   end
 
   def test_rejects_effect_from_another_project
-    mine = Rsk::Projects.new(test_pgsql, "my#{rand(99_999)}").add("t#{rand(99_999)}")
-    other = Rsk::Projects.new(test_pgsql, "you#{rand(99_999)}").add("t#{rand(99_999)}")
+    mine = Rsk::Projects.new(test_pgsql, "my#{SecureRandom.hex(8)}").add("t#{SecureRandom.hex(8)}")
+    other = Rsk::Projects.new(test_pgsql, "you#{SecureRandom.hex(8)}").add("t#{SecureRandom.hex(8)}")
     eid = Rsk::Effects.new(test_pgsql, other).add('other effect')
     assert_raises(Rsk::Urror) { Rsk::Effects.new(test_pgsql, mine).get(eid) }
   end

--- a/test/test_risks.rb
+++ b/test/test_risks.rb
@@ -24,4 +24,11 @@ class Rsk::RisksTest < Minitest::Test
     assert(risks.fetch.any? { |r| r[:id] == rid })
     assert(risks.fetch.any? { |r| r[:text] == text })
   end
+
+  def test_rejects_risk_from_another_project
+    mine = Rsk::Projects.new(test_pgsql, "my#{rand(99_999)}").add("t#{rand(99_999)}")
+    other = Rsk::Projects.new(test_pgsql, "you#{rand(99_999)}").add("t#{rand(99_999)}")
+    rid = Rsk::Risks.new(test_pgsql, other).add('other risk')
+    assert_raises(Rsk::Urror) { Rsk::Risks.new(test_pgsql, mine).get(rid) }
+  end
 end

--- a/test/test_risks.rb
+++ b/test/test_risks.rb
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: MIT
 
 require_relative 'test__helper'
+require 'securerandom'
 require_relative '../objects/rsk'
 require_relative '../objects/risks'
 require_relative '../objects/projects'
@@ -26,8 +27,8 @@ class Rsk::RisksTest < Minitest::Test
   end
 
   def test_rejects_risk_from_another_project
-    mine = Rsk::Projects.new(test_pgsql, "my#{rand(99_999)}").add("t#{rand(99_999)}")
-    other = Rsk::Projects.new(test_pgsql, "you#{rand(99_999)}").add("t#{rand(99_999)}")
+    mine = Rsk::Projects.new(test_pgsql, "my#{SecureRandom.hex(8)}").add("t#{SecureRandom.hex(8)}")
+    other = Rsk::Projects.new(test_pgsql, "you#{SecureRandom.hex(8)}").add("t#{SecureRandom.hex(8)}")
     rid = Rsk::Risks.new(test_pgsql, other).add('other risk')
     assert_raises(Rsk::Urror) { Rsk::Risks.new(test_pgsql, mine).get(rid) }
   end


### PR DESCRIPTION
Fixes #263.

This PR makes the project-scoped `Causes`, `Risks`, and `Effects` collections verify that a requested part id belongs to the collection's project before returning the mutable object. If the id belongs to another project, `Rsk::Urror` is raised instead of allowing the caller to update another tenant's part rows.

I added regression coverage for all three collection types: a cause, risk, or effect created in project B cannot be fetched through a project A collection.

Validation:
- `ruby -c objects/causes.rb objects/risks.rb objects/effects.rb test/test_causes.rb test/test_risks.rb test/test_effects.rb`
- `rubocop objects/causes.rb objects/risks.rb objects/effects.rb test/test_causes.rb test/test_risks.rb test/test_effects.rb`
- fake-PG regression script for project ownership guard behavior
- `git diff --check`
- `gitleaks dir --no-banner --redact .`

Not run: full DB-backed tests. `rake pgsql liquibase` fails in my local Windows Ruby setup with `ArgumentError: unknown keyword: :log` from the `pgtk` rake task, and `bundle install` is blocked by native `openssl`/`psych` build prerequisites missing OpenSSL/libyaml headers.