### PR TITLE
#267: lock plan project lookup in detach

### DIFF
--- a/objects/plan.rb
+++ b/objects/plan.rb
@@ -21,8 +21,9 @@ class Rsk::Plan
 
   def detach
     @pgsql.transaction do |t|
-      if t.exec('SELECT * FROM part WHERE id = $1 AND project = $2', [@part, pid]).empty?
-        raise Rsk::Urror, "##{@id} is not in your project ##{pid}"
+      project = pid(t)
+      if t.exec('SELECT * FROM part WHERE id = $1 AND project = $2', [@part, project]).empty?
+        raise Rsk::Urror, "##{@id} is not in your project ##{project}"
       end
       t.exec('DELETE FROM plan WHERE id = $1 AND part = $2', [@id, @part])
       t.exec('DELETE FROM part WHERE id = $1', [@id]) if t.exec('SELECT * FROM plan WHERE id = $1', [@id]).empty?
@@ -53,7 +54,9 @@ class Rsk::Plan
 
   private
 
-  def pid
-    @pgsql.exec('SELECT project FROM part WHERE id = $1', [@id])[0]['project'].to_i
+  def pid(pgsql = @pgsql)
+    row = pgsql.exec('SELECT project FROM part WHERE id = $1 FOR UPDATE', [@id])[0]
+    raise Rsk::Urror, "Plan part ##{@id} not found" if row.nil?
+    row['project'].to_i
   end
 end

--- a/test/test_plans.rb
+++ b/test/test_plans.rb
@@ -28,4 +28,51 @@ class Rsk::PlansTest < Minitest::Test
     assert(plans.fetch.any? { |p| p[:text] == text })
     plans.get(id, rid).complete
   end
+
+  def test_reports_missing_plan_part
+    err = assert_raises(Rsk::Urror) do
+      Rsk::Plan.new(fake_pool({ 'SELECT project FROM part WHERE id = $1 FOR UPDATE' => [] }), 17, 23).detach
+    end
+    assert_equal('Plan part #17 not found', err.message)
+  end
+
+  def test_finds_project_inside_transaction
+    calls = []
+    Rsk::Plan.new(
+      fake_pool(
+        {
+          'SELECT project FROM part WHERE id = $1 FOR UPDATE' => [{ 'project' => '42' }],
+          'SELECT * FROM part WHERE id = $1 AND project = $2' => [{}],
+          'DELETE FROM plan WHERE id = $1 AND part = $2' => [],
+          'SELECT * FROM plan WHERE id = $1' => [{}]
+        },
+        calls: calls
+      ),
+      17,
+      23
+    ).detach
+    assert_includes(
+      calls,
+      ['SELECT project FROM part WHERE id = $1 FOR UPDATE', [17]]
+    )
+    assert_includes(
+      calls,
+      ['SELECT * FROM part WHERE id = $1 AND project = $2', [23, 42]]
+    )
+  end
+
+  private
+
+  def fake_pool(responses, calls: [])
+    tx = Object.new
+    tx.define_singleton_method(:exec) do |sql, args|
+      calls << [sql, args]
+      raise "Unexpected SQL: #{sql}" unless responses.key?(sql)
+      responses[sql]
+    end
+    pool = Object.new
+    pool.define_singleton_method(:transaction) { |&block| block.call(tx) }
+    pool.define_singleton_method(:exec) { |_sql, _args| raise 'Query escaped the transaction' }
+    pool
+  end
 end


### PR DESCRIPTION
Closes #267.

This patch keeps `Rsk::Plan#detach` on a single transaction path while finding the owning project for the plan part. The project lookup now runs through the transaction connection with `FOR UPDATE`, missing plan parts raise `Rsk::Urror` instead of leaking `NoMethodError`, and the project id is reused instead of calling `pid` twice.

Validation performed locally:

- `PICKS=1 bundle exec ruby -Itest test/test_plans.rb --name '/test_reports_missing_plan_part|test_finds_project_inside_transaction/'` -> 2 tests, 6 assertions, 0 failures, 0 errors\n- `bundle exec rubocop objects/plan.rb test/test_plans.rb` -> 2 files inspected, no offenses\n- `PATH="/usr/lib/postgresql/18/bin:$PATH" bundle exec rake test` as unprivileged local user -> 45 tests, 122 assertions, 0 failures, 0 errors\n- `PATH="/usr/lib/postgresql/18/bin:$PATH" bundle exec rake` as unprivileged local user -> tests passed, RuboCop 46 files no offenses, xcop 14 files clean\n- `git diff --check` -> passed\n- `git show --no-ext-diff --format= --no-renames HEAD | gitleaks stdin --no-banner --redact --exit-code 1` -> no leaks found