### PR TITLE
#209: Return forbidden for anonymous JSON

### DIFF
--- a/front/front_triple.rb
+++ b/front/front_triple.rb
@@ -3,8 +3,13 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
-get '/causes.json' do
+def json_endpoint
+  halt 403 unless @locals[:user]
   content_type('application/json')
+end
+
+get '/causes.json' do
+  json_endpoint
   JSON.pretty_generate(
     causes.fetch(query: params[:query] || '').map do |r|
       {
@@ -20,7 +25,7 @@ get '/causes.json' do
 end
 
 get '/risks.json' do
-  content_type('application/json')
+  json_endpoint
   JSON.pretty_generate(
     risks.fetch(query: params[:query] || '').map do |r|
       {
@@ -36,7 +41,7 @@ get '/risks.json' do
 end
 
 get '/effects.json' do
-  content_type('application/json')
+  json_endpoint
   JSON.pretty_generate(
     effects.fetch(query: params[:query] || '').map do |r|
       {
@@ -53,7 +58,7 @@ get '/effects.json' do
 end
 
 get '/plans.json' do
-  content_type('application/json')
+  json_endpoint
   JSON.pretty_generate(
     plans.fetch(query: params[:query] || '').map do |r|
       {

--- a/test/test_0rsk.rb
+++ b/test/test_0rsk.rb
@@ -71,6 +71,18 @@ class Rsk::AppTest < Minitest::Test
     end
   end
 
+  def test_forbids_anonymous_json_pages
+    [
+      '/causes.json',
+      '/risks.json',
+      '/effects.json',
+      '/plans.json'
+    ].each do |p|
+      get(p)
+      assert_equal(403, last_response.status, "#{p} fails: #{last_response.body}")
+    end
+  end
+
   def test_add
     name = "jeff09#{rand(99_999)}"
     login(name)


### PR DESCRIPTION
/claim #209

Closes #209.

This patch makes the four JSON autocomplete endpoints return HTTP 403 for anonymous requests before they reach the project lookup path that redirects users to the HTML flow. Logged-in users keep the existing JSON behavior.

Validation performed locally:

- `ruby -c front/front_triple.rb` -> Syntax OK
- `ruby -c test/test_0rsk.rb` -> Syntax OK
- `bundle check` -> dependencies satisfied
- `PICKS=1 bundle exec ruby -Itest test/test_0rsk.rb -n test_forbids_anonymous_json_pages` -> 1 test, 4 assertions, 0 failures, 0 errors
- `PICKS=1 bundle exec ruby -Itest test/test_0rsk.rb` -> 8 tests, 36 assertions, 0 failures, 0 errors
- `PICKS=1 bundle exec ruby -Itest -e 'Dir["test/test_*.rb"].sort.each { |f| require_relative f }'` -> 44 tests, 120 assertions, 0 failures, 0 errors
- `bundle exec rubocop front/front_triple.rb test/test_0rsk.rb --format simple` -> 2 files inspected, no offenses
- `bundle exec rake rubocop` -> 46 files inspected, no offenses
- `bundle exec rake xcop` -> 14 files checked, clean
- `bundle exec rake eslint` -> passed
- `git diff --check origin/master...HEAD` -> clean
- `git diff --no-ext-diff origin/master...HEAD | gitleaks stdin --no-banner --redact --exit-code 1 --verbose` -> no leaks found

Local note: this Kali container runs commands as root, while the repo's `pgtk` Rake database task uses `initdb`, which refuses root execution. I therefore ran the full Minitest corpus directly against an isolated PostgreSQL 18 test database initialized under the unprivileged `kali` user and migrated with the repo Liquibase task.
