### PR TITLE
#205: assert deleted triple is gone

### DIFF
--- a/test/test_projects.rb
+++ b/test/test_projects.rb
@@ -7,6 +7,10 @@ require 'yaml'
 require_relative 'test__helper'
 require_relative '../objects/rsk'
 require_relative '../objects/causes'
+require_relative '../objects/effects'
+require_relative '../objects/projects'
+require_relative '../objects/risks'
+require_relative '../objects/triples'
 
 # Test of Projects.
 # Author:: Yegor Bugayenko (yegor256@gmail.com)
@@ -24,12 +28,12 @@ class Rsk::ProjectsTest < Minitest::Test
 
   def test_deletes_with_triple
     projects = Rsk::Projects.new(test_pgsql, 'jeff094')
-    project = projects.add("testfs#{rand(99_999)}")
-    cid = Rsk::Causes.new(test_pgsql, project).add('we have data')
-    rid = Rsk::Risks.new(test_pgsql, project).add('we may lose it')
-    eid = Rsk::Effects.new(test_pgsql, project).add('business will stop NOW')
-    triples = Rsk::Triples.new(test_pgsql, project)
-    triples.add(cid, rid, eid)
-    projects.delete(project)
+    pid = projects.add("testfs#{rand(99_999)}")
+    cid = Rsk::Causes.new(test_pgsql, pid).add('we have data')
+    rid = Rsk::Risks.new(test_pgsql, pid).add('we may lose it')
+    eid = Rsk::Effects.new(test_pgsql, pid).add('business will stop NOW')
+    tid = Rsk::Triples.new(test_pgsql, pid).add(cid, rid, eid)
+    projects.delete(pid)
+    assert_empty(test_pgsql.exec('SELECT * FROM triple WHERE id = $1', [tid]))
   end
 end


### PR DESCRIPTION
/claim #205
Fixes #205

## Summary
- Rename the misleading `project` local to `pid` in `test_deletes_with_triple`.
- Keep the inserted triple id and assert it is absent from the `triple` table after deleting the project.
- Add the explicit object requires needed to run this test file directly.

## Validation
- `ruby -c test/test_projects.rb`
- `git diff --check`
- `git diff -- test/test_projects.rb | gitleaks stdin --no-banner --redact --exit-code 1`
- `mise exec ruby@3.3 -- bundle exec rubocop test/test_projects.rb`
- Docker isolated focused test with Ruby 3.3, PostgreSQL, JRE, and Maven installed in the container.

Focused test result: `1 tests, 2 assertions, 0 failures, 0 errors, 0 skips`.

No secrets, keys, wallet material, or production systems were used.