### PR TITLE
#206: reuse duplicate triple parts

### DIFF
--- a/objects/causes.rb
+++ b/objects/causes.rb
@@ -6,6 +6,7 @@
 require_relative 'rsk'
 require_relative 'cause'
 require_relative 'query'
+require_relative 'urror'
 
 # Causes.
 # Author:: Yegor Bugayenko (yegor256@gmail.com)
@@ -19,12 +20,15 @@ class Rsk::Causes
 
   def add(text)
     @pgsql.transaction do |t|
-      id = t.exec(
-        'INSERT INTO part (project, text, type) VALUES ($1, $2, $3) RETURNING id',
-        [@project, text, 'Cause']
-      )[0]['id'].to_i
-      t.exec('INSERT INTO cause (id) VALUES ($1)', [id])
-      id
+      found = existing(t, text)
+      unless found
+        found = t.exec(
+          'INSERT INTO part (project, text, type) VALUES ($1, $2, $3) RETURNING id',
+          [@project, text, 'Cause']
+        )[0]['id'].to_i
+        t.exec('INSERT INTO cause (id) VALUES ($1)', [found])
+      end
+      found
     end
   end
 
@@ -62,6 +66,13 @@ class Rsk::Causes
   end
 
   private
+
+  def existing(pgsql, text)
+    row = pgsql.exec('SELECT id, type FROM part WHERE project = $1 AND text = $2', [@project, text])[0]
+    return nil if row.nil?
+    raise Rsk::Urror, "#{text.inspect} already exists as #{row['type'].downcase}" unless row['type'] == 'Cause'
+    row['id'].to_i
+  end
 
   def query(query)
     Rsk::Query.new(

--- a/objects/effects.rb
+++ b/objects/effects.rb
@@ -6,6 +6,7 @@
 require_relative 'rsk'
 require_relative 'effect'
 require_relative 'query'
+require_relative 'urror'
 
 # Effects.
 # Author:: Yegor Bugayenko (yegor256@gmail.com)
@@ -19,12 +20,15 @@ class Rsk::Effects
 
   def add(text)
     @pgsql.transaction do |t|
-      id = t.exec(
-        'INSERT INTO part (project, text, type) VALUES ($1, $2, $3) RETURNING id',
-        [@project, text, 'Effect']
-      )[0]['id'].to_i
-      t.exec('INSERT INTO effect (id) VALUES ($1)', [id])
-      id
+      found = existing(t, text)
+      unless found
+        found = t.exec(
+          'INSERT INTO part (project, text, type) VALUES ($1, $2, $3) RETURNING id',
+          [@project, text, 'Effect']
+        )[0]['id'].to_i
+        t.exec('INSERT INTO effect (id) VALUES ($1)', [found])
+      end
+      found
     end
   end
 
@@ -51,6 +55,13 @@ class Rsk::Effects
   end
 
   private
+
+  def existing(pgsql, text)
+    row = pgsql.exec('SELECT id, type FROM part WHERE project = $1 AND text = $2', [@project, text])[0]
+    return nil if row.nil?
+    raise Rsk::Urror, "#{text.inspect} already exists as #{row['type'].downcase}" unless row['type'] == 'Effect'
+    row['id'].to_i
+  end
 
   def query(query)
     Rsk::Query.new(

--- a/objects/risks.rb
+++ b/objects/risks.rb
@@ -6,6 +6,7 @@
 require_relative 'rsk'
 require_relative 'risk'
 require_relative 'query'
+require_relative 'urror'
 
 # Risks.
 # Author:: Yegor Bugayenko (yegor256@gmail.com)
@@ -19,12 +20,15 @@ class Rsk::Risks
 
   def add(text)
     @pgsql.transaction do |t|
-      id = t.exec(
-        'INSERT INTO part (project, text, type) VALUES ($1, $2, $3) RETURNING id',
-        [@project, text, 'Risk']
-      )[0]['id'].to_i
-      t.exec('INSERT INTO risk (id) VALUES ($1)', [id])
-      id
+      found = existing(t, text)
+      unless found
+        found = t.exec(
+          'INSERT INTO part (project, text, type) VALUES ($1, $2, $3) RETURNING id',
+          [@project, text, 'Risk']
+        )[0]['id'].to_i
+        t.exec('INSERT INTO risk (id) VALUES ($1)', [found])
+      end
+      found
     end
   end
 
@@ -50,6 +54,13 @@ class Rsk::Risks
   end
 
   private
+
+  def existing(pgsql, text)
+    row = pgsql.exec('SELECT id, type FROM part WHERE project = $1 AND text = $2', [@project, text])[0]
+    return nil if row.nil?
+    raise Rsk::Urror, "#{text.inspect} already exists as #{row['type'].downcase}" unless row['type'] == 'Risk'
+    row['id'].to_i
+  end
 
   def query(query)
     Rsk::Query.new(

--- a/test/test_0rsk.rb
+++ b/test/test_0rsk.rb
@@ -6,7 +6,10 @@
 require_relative 'test__helper'
 require_relative '../0rsk'
 require_relative '../objects/rsk'
+require_relative '../objects/causes'
+require_relative '../objects/effects'
 require_relative '../objects/projects'
+require_relative '../objects/risks'
 
 module Rack
   module Test
@@ -93,6 +96,33 @@ class Rsk::AppTest < Minitest::Test
     assert_equal(200, last_response.status, last_response.body)
   end
 
+  def test_add_with_duplicate_part_texts
+    name = "jeff10#{rand(99_999)}"
+    pid = login(name)
+    cause = 'duplicate cause'
+    risk = 'duplicate risk'
+    effect = 'duplicate effect'
+    Rsk::Causes.new(test_pgsql, pid).add(cause)
+    Rsk::Risks.new(test_pgsql, pid).add(risk)
+    Rsk::Effects.new(test_pgsql, pid).add(effect)
+    post(
+      '/triple/save',
+      [
+        "ctext=#{cause}",
+        "rtext=#{risk}",
+        'probability=5',
+        'emoji=A',
+        "etext=#{effect}",
+        'impact=5',
+        'cid=',
+        'rid=',
+        'eid='
+      ].join('&')
+    )
+    assert_equal(302, last_response.status, last_response.body)
+    assert_includes(last_response['Location'], '/responses?id=')
+  end
+
   private
 
   def login(name)
@@ -100,5 +130,6 @@ class Rsk::AppTest < Minitest::Test
     projects = Rsk::Projects.new(test_pgsql, name)
     pid = projects.add('test')
     set_cookie("0rsk-project=#{pid}")
+    pid
   end
 end


### PR DESCRIPTION
/claim #206
Fixes #206

Summary:
- Reuse an existing same-type cause, risk, or effect part when `/triple/save` receives duplicate text with an empty id field.
- Raise a user-facing `Rsk::Urror` if the same text already exists as a different part type, instead of leaking a PostgreSQL unique-constraint stacktrace.
- Add a Rack regression that pre-seeds duplicate part texts and submits `/triple/save` with empty `cid`, `rid`, and `eid`.

Validation:
- `ruby -c objects/causes.rb && ruby -c objects/risks.rb && ruby -c objects/effects.rb && ruby -c test/test_0rsk.rb`
- `mise exec ruby@3.3 -- bundle check`
- `mise exec ruby@3.3 -- bundle exec rubocop objects/causes.rb objects/risks.rb objects/effects.rb test/test_0rsk.rb --format simple` -> 4 files inspected, no offenses
- `PICKS=1 mise exec ruby@3.3 -- bundle exec ruby test/test_0rsk.rb -n test_add_with_duplicate_part_texts -- --no-cov` -> 1 test, 3 assertions, 0 failures
- `PICKS=1 mise exec ruby@3.3 -- bundle exec ruby test/test_0rsk.rb -- --no-cov` -> 8 tests, 35 assertions, 0 failures
- Cause/risk/effect object test files passed individually under Ruby 3.3
- `git diff --check`
- diff-only Gitleaks over touched files -> no leaks

Environment note: this Mac has Ruby 3.3 via `mise` but no local `initdb`, so I ran the test database as a disposable local Docker `postgres:16-alpine` container on the repo-configured test port and applied the repo Liquibase schema before the DB-backed tests.

No secrets or credentials are included.