### PR TITLE
#204: mark triple IDs as locked

### DIFF
--- a/test/test_0rsk.rb
+++ b/test/test_0rsk.rb
@@ -71,6 +71,16 @@ class Rsk::AppTest < Minitest::Test
     end
   end
 
+  def test_triple_id_fields_use_locked_cursor
+    login("cursor#{rand(99_999)}")
+    get('/triple')
+    assert_equal(200, last_response.status, last_response.body)
+    assert_includes(last_response.body, '.locked-id { cursor: not-allowed; }')
+    %w[cid rid eid].each do |id|
+      assert_includes(last_response.body, "class='dimmed locked-id' id='#{id}'")
+    end
+  end
+
   def test_add
     name = "jeff09#{rand(99_999)}"
     login(name)

--- a/views/layout.haml
+++ b/views/layout.haml
@@ -24,6 +24,7 @@
       .up { content:url('/up.svg'); width: 1em; height:1em; }
       .down { content:url('/down.svg'); width: 1em; height:1em; }
       .dimmed { background-color: #eee; }
+      .locked-id { cursor: not-allowed; }
   %body
     %section
       %header

--- a/views/triple.haml
+++ b/views/triple.haml
@@ -39,7 +39,7 @@
     Cause:
   %br
   %input#ctext{type: 'text', name: 'ctext', size: 40, autocomplete: 'off', autofocus: 'true', tabindex: 1, value: defined?(triple) ? triple[:ctext] : '', required: true}
-  %input.dimmed#cid{type: 'text', name: 'cid', size: 3, autocomplete: 'off', readonly: true, value: defined?(triple) ? triple[:cid] : '', title: 'The ID of an existing cause'}
+  %input.dimmed.locked-id#cid{type: 'text', name: 'cid', size: 3, autocomplete: 'off', readonly: true, value: defined?(triple) ? triple[:cid] : '', title: 'The ID of an existing cause'}
   %a#ctext_detach.small.item{href: '#', style: defined?(triple) ? '' : 'display: none;', title: 'Click to detach it from the existing cause'} Detach
   %br
   = succeed ':' do
@@ -53,7 +53,7 @@
     Risk:
   %br
   %input#rtext{type: 'text', name: 'rtext', size: 50, maxlength: 160, tabindex: 3, value: defined?(triple) ? triple[:rtext] : '', required: true}
-  %input.dimmed#rid{type: 'text', name: 'rid', size: 3, autocomplete: 'off', readonly: true, value: defined?(triple) ? triple[:rid] : '', title: 'The ID of an existing risk'}
+  %input.dimmed.locked-id#rid{type: 'text', name: 'rid', size: 3, autocomplete: 'off', readonly: true, value: defined?(triple) ? triple[:rid] : '', title: 'The ID of an existing risk'}
   %a#rtext_detach.small.item{href: '#', style: defined?(triple) ? '' : 'display: none;', title: 'Click to detach it from the existing risk'} Detach
   %br
   %label
@@ -67,7 +67,7 @@
     Effect:
   %br
   %input#etext{type: 'text', name: 'etext', size: 60, maxlength: 160, autocomplete: 'off', tabindex: 5, value: defined?(triple) ? triple[:etext] : '', required: true}
-  %input.dimmed#eid{type: 'text', name: 'eid', size: 3, autocomplete: 'off', readonly: true, value: defined?(triple) ? triple[:eid] : '', title: 'The ID of an existing effect'}
+  %input.dimmed.locked-id#eid{type: 'text', name: 'eid', size: 3, autocomplete: 'off', readonly: true, value: defined?(triple) ? triple[:eid] : '', title: 'The ID of an existing effect'}
   %a#etext_detach.small.item{href: '#', style: defined?(triple) ? '' : 'display: none;', title: 'Click to detach it from the existing effect'} Detach
   %br
   %label


### PR DESCRIPTION
/claim #204
Fixes #204

Summary:
- add a locked cursor class for read-only triple ID fields
- apply it to the cause, risk, and effect ID inputs on `/triple`
- add a Rack render regression covering the three locked ID fields

Validation:
- `ruby -c test/test_0rsk.rb`
- `ruby -c 0rsk.rb`
- `PICKS=1 mise exec ruby@3.3.11 -- bundle exec ruby test/test_0rsk.rb -n test_triple_id_fields_use_locked_cursor -- --no-cov` -> `1 tests, 9 assertions, 0 failures, 0 errors, 0 skips`
- `PICKS=1 mise exec ruby@3.3.11 -- bundle exec ruby test/test_0rsk.rb -- --no-cov` -> `8 tests, 41 assertions, 0 failures, 0 errors, 0 skips`
- `mise exec ruby@3.3.11 -- bundle exec rubocop test/test_0rsk.rb --format simple` -> `1 file inspected, no offenses detected`
- `git diff --check`
- diff-only Gitleaks over the patch -> no leaks found

No secrets or generated private files are included. DB-backed tests used a disposable local Docker `postgres:16-alpine` container and the repo Liquibase migrations.
