### PR TITLE
#299: restrict debug login to non-production environments

### DIFF
--- a/front/front_login.rb
+++ b/front/front_login.rb
@@ -5,7 +5,9 @@
 
 before '/*' do
   @locals = { http_start: Time.now, ver: Rsk::VERSION, login_link: settings.glogin.login_uri, request_ip: request.ip }
-  response.set_cookie('glogin', params[:glogin]) if params[:glogin]
+  if params[:glogin] && ENV['RACK_ENV'] != 'production'
+    response.set_cookie('glogin', params[:glogin])
+  end
   if request.cookies['glogin']
     begin
       @locals[:user] = GLogin::Cookie::Closed.new(


### PR DESCRIPTION
The `?glogin=` URL parameter allows setting the authentication cookie directly from a query string parameter, bypassing the normal GitHub OAuth flow.

This is a documented development convenience (see glogin gem README) intended for local testing. However, the feature is currently active in all environments, creating an unnecessary attack surface in production.

While the production environment typically has a non-empty `encryption_secret` (which causes `GLogin::Cookie::Closed` to reject plaintext values and raise `DecodingError`), defense-in-depth dictates that the debug backdoor should not be reachable at all in production.

**Fix:** guard `?glogin=` with `ENV["RACK_ENV"] != "production"`, matching the existing environment checks in `0rsk.rb`.

**Testing:** The existing test uses `set_cookie("glogin=#{name}")` directly (not `?glogin=`), so no test changes are needed.