### PR TITLE
#300: escape LIKE wildcards in search queries

### DIFF
--- a/objects/causes.rb
+++ b/objects/causes.rb
@@ -79,7 +79,7 @@ class Rsk::Causes
         'GROUP BY cause.id, part.id',
         'ORDER BY rank DESC'
       ],
-      [@project, "%#{query.to_s.downcase.strip}%"]
+      [@project, "%#{query.to_s.downcase.strip.gsub(/[%_]/, '\\\\\0')}%"]
     )
   end
 end

--- a/objects/effects.rb
+++ b/objects/effects.rb
@@ -69,7 +69,7 @@ class Rsk::Effects
         'GROUP BY effect.id, part.id',
         'ORDER BY rank DESC'
       ],
-      [@project, "%#{query.to_s.downcase.strip}%"]
+      [@project, "%#{query.to_s.downcase.strip.gsub(/[%_]/, '\\\\\0')}%"]
     )
   end
 end

--- a/objects/plans.rb
+++ b/objects/plans.rb
@@ -76,7 +76,7 @@ class Rsk::Plans
         query.is_a?(Integer) ? 'triple.id = $2' : 'LOWER(part.text) LIKE $2',
         'ORDER BY rank DESC'
       ],
-      [@project, query.is_a?(Integer) ? query : "%#{query.to_s.downcase.strip}%"]
+      [@project, query.is_a?(Integer) ? query : "%#{query.to_s.downcase.strip.gsub(/[%_]/, '\\\\\0')}%"]
     )
   end
 end

--- a/objects/risks.rb
+++ b/objects/risks.rb
@@ -67,7 +67,7 @@ class Rsk::Risks
         'GROUP BY risk.id, part.id',
         'ORDER BY rank DESC'
       ],
-      [@project, "%#{query.to_s.downcase.strip}%"]
+      [@project, "%#{query.to_s.downcase.strip.gsub(/[%_]/, '\\\\\0')}%"]
     )
   end
 end

--- a/objects/tasks.rb
+++ b/objects/tasks.rb
@@ -119,7 +119,7 @@ class Rsk::Tasks
         'ORDER BY task.id ASC) x',
         'ORDER BY rank DESC'
       ],
-      [@login, query.is_a?(Integer) ? query : "%#{query.to_s.downcase.strip}%"]
+      [@login, query.is_a?(Integer) ? query : "%#{query.to_s.downcase.strip.gsub(/[%_]/, '\\\\\0')}%"]
     )
   end
 

--- a/objects/triples.rb
+++ b/objects/triples.rb
@@ -130,7 +130,7 @@ class Rsk::Triples
         where.empty? ? '' : "AND (#{where.join(') AND (')})",
         'ORDER BY rank DESC, t.created DESC'
       ],
-      [@project, id.positive? ? id : "%#{words.join(' ')}%"]
+      [@project, id.positive? ? id : "%#{words.join(' ').gsub(/[%_]/, '\\\\\0')}%"]
     )
   end
 end


### PR DESCRIPTION
The SQL `LIKE` operator interprets `%` as any sequence and `_` as exactly one character. User-supplied search terms are interpolated directly into LIKE patterns without escaping.

**Affected files:** `causes.rb`, `risks.rb`, `effects.rb`, `plans.rb`, `triples.rb`, `tasks.rb`

The existing pattern:
```ruby
"%#{query.to_s.downcase.strip}%"
```

Allows a query of `%` or `____` to match unintended records.

**Fix:** escape `%` and `_` with `.gsub(/[%_]/, '\\\\\0')` before building the LIKE pattern.

**Impact:** minimal — 6 one-line changes. No test changes needed (existing tests don't search with `%` or `_`).