### PR TITLE
#301: add Content-Security-Policy header

### DIFF
--- a/front/front_login.rb
+++ b/front/front_login.rb
@@ -4,6 +4,16 @@
 # SPDX-License-Identifier: MIT
 
 before '/*' do
+  response.headers['Content-Security-Policy'] = [
+    "default-src 'self'",
+    "script-src 'self' 'unsafe-inline' code.jquery.com cdnjs.cloudflare.com",
+    "style-src 'self' 'unsafe-inline' cdn.jsdelivr.net cdnjs.cloudflare.com www.yegor256.com",
+    "img-src 'self' img.shields.io www.sixnines.io",
+    "font-src 'self'",
+    "frame-ancestors 'none'",
+    "base-uri 'self'",
+    "form-action 'self'"
+  ].join('; ')
   @locals = { http_start: Time.now, ver: Rsk::VERSION, login_link: settings.glogin.login_uri, request_ip: request.ip }
   response.set_cookie('glogin', params[:glogin]) if params[:glogin]
   if request.cookies['glogin']


### PR DESCRIPTION
Add a Content-Security-Policy header to protect against XSS attacks.

The policy covers all external resources loaded by the application:

Scripts: self, code.jquery.com, cdnjs.cloudflare.com (jQuery UI), plus 'unsafe-inline' for existing onclick handlers in views.

Styles: self, cdn.jsdelivr.net (Tacit CSS), cdnjs.cloudflare.com (jQuery UI CSS), www.yegor256.com (icons.css), plus 'unsafe-inline' for the inline CSS block in layout.haml.

Images: self, img.shields.io, www.sixnines.io.

Additional protections: frame-ancestors 'none' (clickjacking), form-action 'self' (form CSRF), base-uri 'self' (base tag injection).

The policy is set in the global before filter alongside the existing auth logic.