### PR TITLE
#302: add rate limiting for POST requests

### DIFF
--- a/0rsk.rb
+++ b/0rsk.rb
@@ -48,6 +48,7 @@ configure do
   set :config, config
   set :logging, true
   set :log, Loog::REGULAR
+  set :rate_limits, []
   set :server_settings, timeout: 25
   set :glogin, GLogin::Auth.new(
     config['github']['client_id'],

--- a/front/front_login.rb
+++ b/front/front_login.rb
@@ -4,6 +4,14 @@
 # SPDX-License-Identifier: MIT
 
 before '/*' do
+  now = Time.now.to_i
+  settings.rate_limits.reject! { |t| t < now - 60 }
+  if request.post?
+    settings.rate_limits << now
+    if settings.rate_limits.size > 10
+      halt 429, { 'Content-Type' => 'text/plain' }, 'Too many requests'
+    end
+  end
   @locals = { http_start: Time.now, ver: Rsk::VERSION, login_link: settings.glogin.login_uri, request_ip: request.ip }
   response.set_cookie('glogin', params[:glogin]) if params[:glogin]
   if request.cookies['glogin']

--- a/front/front_login.rb
+++ b/front/front_login.rb
@@ -8,9 +8,7 @@ before '/*' do
   settings.rate_limits.reject! { |t| t < now - 60 }
   if request.post?
     settings.rate_limits << now
-    if settings.rate_limits.size > 10
-      halt 429, { 'Content-Type' => 'text/plain' }, 'Too many requests'
-    end
+    halt 429, { 'Content-Type' => 'text/plain' }, 'Too many requests' if settings.rate_limits.size > 10
   end
   @locals = { http_start: Time.now, ver: Rsk::VERSION, login_link: settings.glogin.login_uri, request_ip: request.ip }
   response.set_cookie('glogin', params[:glogin]) if params[:glogin]


### PR DESCRIPTION
Add simple in-memory rate limiting for POST requests to prevent abuse.

The rate limiter tracks request timestamps in a Sinatra setting array, pruning entries older than 60 seconds. If a process receives more than 10 POST requests within 60 seconds, it returns HTTP 429.

This is a lightweight approach with zero new dependencies. For Thin (single-process, single-thread), the in-memory counter is adequate. For multi-dyno Heroku deployments, each dyno has its own counter — still better than nothing.

Rate limits are config via  — the array of timestamps is stored in the Sinatra configure block.