### PR TITLE
#304: fix email link typo maito -> mailto in terms page

### DIFF
--- a/views/terms.haml
+++ b/views/terms.haml
@@ -40,4 +40,4 @@
 %p
   If any questions,
   = succeed '.' do
-    %a{href: 'maito:terms@0rsk.com'} email us
+    %a{href: 'mailto:terms@0rsk.com'} email us


### PR DESCRIPTION
Line 43 of views/terms.haml has a typo: `maito:` instead of `mailto:`.

The email link is broken: clicking it opens `maito:terms@0rsk.com` which no email client recognizes.