### PR TITLE
#306: add daemon test

### DIFF
--- a/test/test_daemon.rb
+++ b/test/test_daemon.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'test__helper'
+require_relative '../objects/daemon'
+
+class Rsk::DaemonTest < Minitest::Test
+  def test_starts_and_stops
+    counter = 0
+    daemon = Rsk::Daemon.new(0.01)
+    thread = daemon.start { counter += 1 }
+    sleep 1.5
+    thread.kill
+    assert_operator counter, :>=, 1
+  end
+end


### PR DESCRIPTION
Add tests for Rsk::Daemon.

Rsk::Daemon is a simple thread loop with no dependencies on PostgreSQL, making it easy to test in isolation.

Tests:
- test_starts_and_stops: verify the daemon thread runs the block at least once