### PR TITLE
#307: add query test

### DIFF
--- a/test/test_query.rb
+++ b/test/test_query.rb
@@ -11,14 +11,14 @@ class Rsk::QueryTest < Minitest::Test
     sql = ['SELECT * FROM project WHERE login = $1']
     query = Rsk::Query.new(test_pgsql, sql, ['test'])
     rows = query.fetch(0, 10)
-    assert rows.is_a?(Array)
+    assert_kind_of(Array, rows)
   end
 
   def test_fetch_second_page
     sql = ['SELECT * FROM project WHERE login = $1']
     query = Rsk::Query.new(test_pgsql, sql, ['test'])
     rows = query.fetch(10, 10)
-    assert rows.is_a?(Array)
+    assert_kind_of(Array, rows)
   end
 
   def test_count
@@ -37,6 +37,6 @@ class Rsk::QueryTest < Minitest::Test
     sql = ['SELECT * FROM project WHERE login = $1']
     query = Rsk::Query.new(test_pgsql, sql, ['nonexistent_login'])
     rows = query.fetch(0, 0)
-    assert rows.is_a?(Array)
+    assert_kind_of(Array, rows)
   end
 end

--- a/test/test_query.rb
+++ b/test/test_query.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'test__helper'
+require_relative '../objects/query'
+
+class Rsk::QueryTest < Minitest::Test
+  def test_fetch_pagination
+    sql = ['SELECT * FROM project WHERE login = $1']
+    query = Rsk::Query.new(test_pgsql, sql, ['test'])
+    rows = query.fetch(0, 10)
+    assert rows.is_a?(Array)
+  end
+
+  def test_fetch_second_page
+    sql = ['SELECT * FROM project WHERE login = $1']
+    query = Rsk::Query.new(test_pgsql, sql, ['test'])
+    rows = query.fetch(10, 10)
+    assert rows.is_a?(Array)
+  end
+
+  def test_count
+    sql = ['SELECT 1 AS x']
+    query = Rsk::Query.new(test_pgsql, sql, [])
+    assert_equal(1, query.count)
+  end
+
+  def test_count_integer
+    sql = ['SELECT generate_series(1, 5) AS x']
+    query = Rsk::Query.new(test_pgsql, sql, [])
+    assert_equal(5, query.count)
+  end
+
+  def test_empty_fetch
+    sql = ['SELECT * FROM project WHERE login = $1']
+    query = Rsk::Query.new(test_pgsql, sql, ['nonexistent_login'])
+    rows = query.fetch(0, 0)
+    assert rows.is_a?(Array)
+  end
+end


### PR DESCRIPTION
Add tests for Rsk::Query.

Tests cover:
- test_fetch_pagination: fetch with offset=0 limit=10 returns Array
- test_fetch_second_page: offset=10 limit=10 works
- test_count: COUNT wraps SQL and returns correct count (1 for SELECT 1)
- test_count_integer: COUNT returns correct value for multi-row queries (generate_series 1..5)
- test_empty_fetch: empty result with limit=0 returns Array