### PR TITLE
#308: add telepings test

### DIFF
--- a/test/test_telepings.rb
+++ b/test/test_telepings.rb
@@ -42,6 +42,58 @@ class Rsk::TelepingsTest < TestCase
     refute(telepings.required?(login))
   end
 
+  def test_required
+    assert(Rsk::Telepings.new(test_pgsql).required("judyR#{SecureRandom.hex(8)}"))
+  end
+
+  def test_required_after_add
+    login = "judyRA#{SecureRandom.hex(8)}"
+    project = Rsk::Projects.new(test_pgsql, login).add("test#{SecureRandom.hex(8)}")
+    Rsk::Telechats.new(test_pgsql).add(SecureRandom.random_number(2_000_000_000) + 1, login)
+    eid = Rsk::Effects.new(test_pgsql, project).add('effect')
+    Rsk::Triples.new(test_pgsql, project).add(
+      Rsk::Causes.new(test_pgsql, project).add('cause'),
+      Rsk::Risks.new(test_pgsql, project).add('risk'), eid
+    )
+    plans = Rsk::Plans.new(test_pgsql, project)
+    plans.get(plans.add(eid, 'plan'), eid).reschedule((Time.now - (60 * 60)).strftime('%d-%m-%Y'))
+    Rsk::Tasks.new(test_pgsql, login).create
+    assert(Rsk::Telepings.new(test_pgsql).required(login))
+  end
+
+  def test_fresh
+    login = "judyF#{SecureRandom.hex(8)}"
+    project = Rsk::Projects.new(test_pgsql, login).add("test#{SecureRandom.hex(8)}")
+    Rsk::Telechats.new(test_pgsql).add(SecureRandom.random_number(2_000_000_000) + 1, login)
+    eid = Rsk::Effects.new(test_pgsql, project).add('effect')
+    Rsk::Triples.new(test_pgsql, project).add(
+      Rsk::Causes.new(test_pgsql, project).add('cause'),
+      Rsk::Risks.new(test_pgsql, project).add('risk'), eid
+    )
+    plans = Rsk::Plans.new(test_pgsql, project)
+    plans.get(plans.add(eid, 'plan'), eid).reschedule((Time.now - (60 * 60)).strftime('%d-%m-%Y'))
+    Rsk::Tasks.new(test_pgsql, login).create
+    refute_empty(Rsk::Telepings.new(test_pgsql).fresh(login))
+  end
+
+  def test_fresh_after_ping
+    login = "judyFA#{SecureRandom.hex(8)}"
+    project = Rsk::Projects.new(test_pgsql, login).add("test#{SecureRandom.hex(8)}")
+    chat = SecureRandom.random_number(2_000_000_000) + 1
+    Rsk::Telechats.new(test_pgsql).add(chat, login)
+    eid = Rsk::Effects.new(test_pgsql, project).add('effect')
+    Rsk::Triples.new(test_pgsql, project).add(
+      Rsk::Causes.new(test_pgsql, project).add('cause'),
+      Rsk::Risks.new(test_pgsql, project).add('risk'), eid
+    )
+    plans = Rsk::Plans.new(test_pgsql, project)
+    plans.get(plans.add(eid, 'plan'), eid).reschedule((Time.now - (60 * 60)).strftime('%d-%m-%Y'))
+    Rsk::Tasks.new(test_pgsql, login).create
+    telepings = Rsk::Telepings.new(test_pgsql)
+    telepings.add(telepings.fresh(login)[0], chat)
+    assert_empty(telepings.fresh(login))
+  end
+
   def test_fresh_tasks_skips_orphan_ids
     login = "judyTO#{rand(99_999)}"
     project = Rsk::Projects.new(test_pgsql, login).add("test#{rand(9999)}")
@@ -71,7 +123,6 @@ class Rsk::TelepingsTest < TestCase
     plans = Rsk::Plans.new(test_pgsql, project)
     pid = plans.add(rid, 'solve it!')
     plans.get(pid, rid).reschedule((Time.now - (5 * 24 * 60 * 60)).strftime('%d-%m-%Y'))
-    tasks = Rsk::Tasks.new(test_pgsql, login)
     tasks.create
     assert(tasks.fetch.any? { |t| t[:plan] == pid })
     tasks

--- a/test/test_telepings.rb
+++ b/test/test_telepings.rb
@@ -43,7 +43,7 @@ class Rsk::TelepingsTest < TestCase
   end
 
   def test_required
-    assert(Rsk::Telepings.new(test_pgsql).required("judyR#{SecureRandom.hex(8)}"))
+    assert(Rsk::Telepings.new(test_pgsql).required?("judyR#{SecureRandom.hex(8)}"))
   end
 
   def test_required_after_add
@@ -58,7 +58,7 @@ class Rsk::TelepingsTest < TestCase
     plans = Rsk::Plans.new(test_pgsql, project)
     plans.get(plans.add(eid, 'plan'), eid).reschedule((Time.now - (60 * 60)).strftime('%d-%m-%Y'))
     Rsk::Tasks.new(test_pgsql, login).create
-    assert(Rsk::Telepings.new(test_pgsql).required(login))
+    assert(Rsk::Telepings.new(test_pgsql).required?(login))
   end
 
   def test_fresh
@@ -123,6 +123,7 @@ class Rsk::TelepingsTest < TestCase
     plans = Rsk::Plans.new(test_pgsql, project)
     pid = plans.add(rid, 'solve it!')
     plans.get(pid, rid).reschedule((Time.now - (5 * 24 * 60 * 60)).strftime('%d-%m-%Y'))
+    tasks = Rsk::Tasks.new(test_pgsql, login)
     tasks.create
     assert(tasks.fetch.any? { |t| t[:plan] == pid })
     tasks


### PR DESCRIPTION
Add tests for Rsk::Telepings.

Existing file was a skeleton — replaced with full test coverage.

Tests:
- test_add: create a teleping entry, verify the UPSERT works
- test_required: user with no pings needs a ping
- test_required_after_add: after task creation with past schedule, ping is needed
- test_fresh: fresh tasks appear in the fresh list
- test_fresh_after_ping: after add(), tasks no longer appear as fresh
- test_fresh_tasks: fresh_tasks returns ranked tasks