### PR TITLE
#309: add plan schedule tests

### DIFF
--- a/test/test_plans.rb
+++ b/test/test_plans.rb
@@ -11,6 +11,7 @@ require_relative '../objects/plans'
 require_relative '../objects/projects'
 require_relative '../objects/risks'
 require_relative '../objects/rsk'
+require 'securerandom'
 require_relative '../objects/triples'
 
 class Rsk::PlansTest < TestCase
@@ -39,5 +40,104 @@ class Rsk::PlansTest < TestCase
     plans.add(cid, 'mitigate it')
     assert_equal(1, plans.count)
     assert_equal(1, plans.fetch.length)
+  end
+
+  def test_schedule_daily
+    pid = Rsk::Projects.new(
+      test_pgsql,
+      "dly#{SecureRandom.random_number(2_000_000_000) + 1}"
+    ).add("test#{SecureRandom.random_number(2_000_000_000) + 1}")
+    rid = Rsk::Risks.new(test_pgsql, pid).add('risk')
+    plans = Rsk::Plans.new(test_pgsql, pid)
+    plan = plans.get(plans.add(rid, 'plan'), rid)
+    plan.reschedule('daily')
+    assert_equal('daily', plan.schedule)
+  end
+
+  def test_schedule_weekly
+    pid = Rsk::Projects.new(
+      test_pgsql,
+      "wkly#{SecureRandom.random_number(2_000_000_000) + 1}"
+    ).add("test#{SecureRandom.random_number(2_000_000_000) + 1}")
+    rid = Rsk::Risks.new(test_pgsql, pid).add('risk')
+    plans = Rsk::Plans.new(test_pgsql, pid)
+    plan = plans.get(plans.add(rid, 'plan'), rid)
+    plan.reschedule('weekly')
+    assert_equal('weekly', plan.schedule)
+  end
+
+  def test_schedule_monthly
+    pid = Rsk::Projects.new(
+      test_pgsql,
+      "mnth#{SecureRandom.random_number(2_000_000_000) + 1}"
+    ).add("test#{SecureRandom.random_number(2_000_000_000) + 1}")
+    rid = Rsk::Risks.new(test_pgsql, pid).add('risk')
+    plans = Rsk::Plans.new(test_pgsql, pid)
+    plan = plans.get(plans.add(rid, 'plan'), rid)
+    plan.reschedule('monthly')
+    assert_equal('monthly', plan.schedule)
+  end
+
+  def test_schedule_quarterly
+    pid = Rsk::Projects.new(
+      test_pgsql,
+      "qtr#{SecureRandom.random_number(2_000_000_000) + 1}"
+    ).add("test#{SecureRandom.random_number(2_000_000_000) + 1}")
+    rid = Rsk::Risks.new(test_pgsql, pid).add('risk')
+    plans = Rsk::Plans.new(test_pgsql, pid)
+    plan = plans.get(plans.add(rid, 'plan'), rid)
+    plan.reschedule('quarterly')
+    assert_equal('quarterly', plan.schedule)
+  end
+
+  def test_schedule_annually
+    pid = Rsk::Projects.new(
+      test_pgsql,
+      "ann#{SecureRandom.random_number(2_000_000_000) + 1}"
+    ).add("test#{SecureRandom.random_number(2_000_000_000) + 1}")
+    rid = Rsk::Risks.new(test_pgsql, pid).add('risk')
+    plans = Rsk::Plans.new(test_pgsql, pid)
+    plan = plans.get(plans.add(rid, 'plan'), rid)
+    plan.reschedule('annually')
+    assert_equal('annually', plan.schedule)
+  end
+
+  def test_schedule_date
+    pid = Rsk::Projects.new(
+      test_pgsql,
+      "dt#{SecureRandom.random_number(2_000_000_000) + 1}"
+    ).add("test#{SecureRandom.random_number(2_000_000_000) + 1}")
+    rid = Rsk::Risks.new(test_pgsql, pid).add('risk')
+    plans = Rsk::Plans.new(test_pgsql, pid)
+    plan = plans.get(plans.add(rid, 'plan'), rid)
+    plan.reschedule('25-12-2025')
+    assert_equal('25-12-2025', plan.schedule)
+  end
+
+  def test_complete
+    pid = Rsk::Projects.new(
+      test_pgsql,
+      "cmp#{SecureRandom.random_number(2_000_000_000) + 1}"
+    ).add("test#{SecureRandom.random_number(2_000_000_000) + 1}")
+    rid = Rsk::Risks.new(test_pgsql, pid).add('risk')
+    plans = Rsk::Plans.new(test_pgsql, pid)
+    plan = plans.get(plans.add(rid, 'plan'), rid)
+    plan.reschedule('daily')
+    plan.complete
+    refute_nil(plan.schedule)
+  end
+
+  def test_detach
+    pid = Rsk::Projects.new(
+      test_pgsql,
+      "det#{SecureRandom.random_number(2_000_000_000) + 1}"
+    ).add("test#{SecureRandom.random_number(2_000_000_000) + 1}")
+    eid = Rsk::Effects.new(test_pgsql, pid).add('effect')
+    Rsk::Triples.new(test_pgsql, pid).add(
+      Rsk::Causes.new(test_pgsql, pid).add('cause'),
+      Rsk::Risks.new(test_pgsql, pid).add('risk'), eid
+    )
+    plans = Rsk::Plans.new(test_pgsql, pid)
+    plans.get(plans.add(eid, 'plan'), eid).detach
   end
 end


### PR DESCRIPTION
Add schedule tests for Rsk::Plan and Rsk::Plans.

Tests added to the existing test_plans.rb:
- test_schedule_daily: set and verify 'daily' schedule
- test_schedule_weekly: set and verify 'weekly'
- test_schedule_monthly: set and verify 'monthly'
- test_schedule_quarterly: set and verify 'quarterly'
- test_schedule_annually: set and verify 'annually'
- test_schedule_date: set and verify date format 'DD-MM-YYYY'
- test_complete: complete a daily plan
- test_detach: detach a plan from its triple