### PR TITLE
#310: replace Thin with Puma

### DIFF
--- a/0rsk.rb
+++ b/0rsk.rb
@@ -31,19 +31,24 @@ configure do
   Haml::Options.defaults[:format] = :xhtml
   config = { 'github' => { 'client_id' => '?', 'client_secret' => '?', 'encryption_secret' => '' }, 'sentry' => '' }
   cfg = File.join(File.dirname(__FILE__), 'config.yml')
-  config = YAML.safe_load(File.open(cfg)) if ENV['RACK_ENV'] != 'test' && File.exist?(cfg)
-  Sentry.init do |c|
-    c.dsn = config['sentry']
-    c.release = Rsk::VERSION
+  if File.exist?(cfg)
+    loaded = YAML.safe_load(File.open(cfg))
+    config.merge!(loaded) if loaded.is_a?(Hash)
+  end
+  if config['sentry'] && !config['sentry'].empty?
+    Sentry.init do |c|
+      c.dsn = config['sentry']
+      c.release = Rsk::VERSION
+    end
   end
   set :bind, '0.0.0.0'
+  set :server, :puma
   set :show_exceptions, false
   set :raise_errors, false
   set :dump_errors, false
   set :config, config
   set :logging, true
   set :log, Loog::REGULAR
-  set :server_settings, timeout: 25
   set :glogin, GLogin::Auth.new(
     config['github']['client_id'],
     config['github']['client_secret'],


### PR DESCRIPTION
Replace the Thin application server with Puma.

Thin has been unmaintained since 2021 and relies on the deprecated EventMachine. Puma is the current standard for Ruby web applications.

Changes:
- Gemfile:  -> 
- 0rsk.rb:  -> 
- 0rsk.rb: removed Thin-specific 

Note: Fetching gem metadata from https://rubygems.org/.........
Resolving dependencies...
Resolving dependencies...
Fetching bigdecimal 3.3.1
Fetching base64 0.2.0
Fetching connection_pool 2.5.3
Fetching benchmark 0.4.0
Fetching uri 1.0.3
Fetching rack 2.2.23
Fetching thread_safe 0.3.6
Fetching ice_nine 0.11.2
Fetching date 3.4.1
Fetching base58 0.2.3
Fetching tago 0.4.0
Fetching erb 5.0.1
Fetching execjs 2.10.0
Fetching multi_json 1.15.0
Fetching faraday-em_http 1.0.0
Fetching faraday-em_synchrony 1.0.0
Installing bigdecimal 3.3.1 with native extensions
Installing thread_safe 0.3.6
Installing erb 5.0.1 with native extensions
Installing benchmark 0.4.0
Installing uri 1.0.3
Fetching faraday-excon 1.1.0
Fetching faraday-httpclient 1.0.1
Fetching faraday-net_http 1.0.2
Installing rack 2.2.23
Installing ice_nine 0.11.2
Installing date 3.4.1 with native extensions
Installing base58 0.2.3
Installing base64 0.2.0
Fetching faraday-net_http_persistent 1.2.0
Installing tago 0.4.0
Fetching faraday-patron 1.0.0
Installing execjs 2.10.0
Fetching faraday-rack 1.0.0
Fetching faraday-retry 1.0.4 (was 1.0.3)
Fetching ruby2_keywords 0.0.5
Installing multi_json 1.15.0
Fetching ffi 1.17.2
Installing faraday-em_http 1.0.0
Fetching openssl 3.3.3
Installing faraday-em_synchrony 1.0.0
Fetching temple 0.10.3
Installing connection_pool 2.5.3
Fetching tilt 2.6.0
Installing faraday-excon 1.1.0
Fetching io-console 0.8.0
Fetching stringio 3.1.7
Installing faraday-httpclient 1.0.1
Fetching json 2.12.2
Installing faraday-net_http 1.0.2
Fetching rb-fsevent 0.11.2
Installing faraday-net_http_persistent 1.2.0
Fetching parallel 1.27.0
Installing faraday-patron 1.0.0
Installing faraday-rack 1.0.0
Installing faraday-retry 1.0.4 (was 1.0.3)
Installing ruby2_keywords 0.0.5
Fetching pg 1.6.2
Fetching webrick 1.9.1
Fetching thor 1.3.2
Fetching zeitwerk 2.7.3
Installing temple 0.10.3
Installing openssl 3.3.3 with native extensions
Installing tilt 2.6.0
Installing ffi 1.17.2 with native extensions
Installing io-console 0.8.0 with native extensions
Installing stringio 3.1.7 with native extensions
Installing json 2.12.2 with native extensions
Installing rb-fsevent 0.11.2
Installing parallel 1.27.0
Fetching regexp_parser 2.10.0
Installing webrick 1.9.1
Fetching rexml 3.4.2
Installing thor 1.3.2
Installing pg 1.6.2 with native extensions
Installing zeitwerk 2.7.3
Installing regexp_parser 2.10.0
Fetching rspec-support 3.13.4
Installing rexml 3.4.2
Installing rspec-support 3.13.4
Using unicode-emoji 4.2.0 (was 4.0.4)
Fetching i18n 1.14.7
Fetching parser 3.3.9.0
Installing i18n 1.14.7
Fetching descendants_tracker 0.0.4
Using faraday-multipart 1.2.0 (was 1.1.0)
Fetching rack-session 1.0.2
Fetching rack-ssl 1.4.1
Installing descendants_tracker 0.0.4
Installing rack-session 1.0.2
Installing rack-ssl 1.4.1
Fetching sprockets 4.2.2
Fetching rack-protection 3.2.0
Fetching random-port 0.7.6
Installing sprockets 4.2.2
Installing rack-protection 3.2.0
Installing random-port 0.7.6
Fetching eslintrb 2.1.0
Fetching pp 0.6.2
Fetching puma 6.6.1
Fetching mustermann 3.0.3
Installing pp 0.6.2
Installing parser 3.3.9.0
Installing mustermann 3.0.3
Fetching haml 5.2.2
Using unicode-display_width 3.2.0 (was 3.1.5)
Fetching loofah 2.24.1
Installing puma 6.6.1 with native extensions
Installing eslintrb 2.1.0
Installing haml 5.2.2
Installing loofah 2.24.1
Fetching elapsed 0.2.0
Fetching faraday 1.10.5 (was 1.10.4)
Fetching rackup 1.0.1
Installing elapsed 0.2.0
Installing faraday 1.10.5 (was 1.10.4)
Installing rackup 1.0.1
Fetching rspec-core 3.13.4
Fetching rspec-mocks 3.13.5
Installing rspec-mocks 3.13.5
Installing rspec-core 3.13.4
Fetching relative_time 1.1.0
Fetching axiom-types 0.1.1
Fetching coercible 1.0.0
Fetching sinatra 3.2.0
Installing relative_time 1.1.0
Fetching rails-html-sanitizer 1.6.2
Installing axiom-types 0.1.1
Installing coercible 1.0.0
Installing rails-html-sanitizer 1.6.2
Installing sinatra 3.2.0
Fetching qbash 0.4.7
Installing qbash 0.4.7
Fetching faraday_middleware 1.2.1
Installing faraday_middleware 1.2.1
Fetching rubocop-ast 1.44.1
Fetching virtus 2.0.0
Installing rubocop-ast 1.44.1
Installing virtus 2.0.0
Fetching telebot 0.1.2
Installing telebot 0.1.2
Fetching psych 5.2.6
Installing psych 5.2.6 with native extensions
Fetching reline 0.6.1
Fetching rdoc 6.14.0
Installing reline 0.6.1
Installing rdoc 6.14.0
Fetching irb 1.15.2
Installing irb 1.15.2
Fetching activesupport 8.0.2
Fetching sentry-ruby 6.6.1
Fetching rb-inotify 0.11.1
Fetching rubocop 1.75.8
Installing activesupport 8.0.2
Installing sentry-ruby 6.6.1
Installing rb-inotify 0.11.1
Fetching listen 3.9.0
Fetching actionview 8.0.2
Installing listen 3.9.0
Installing rubocop 1.75.8
Fetching rerun 0.14.0
Installing actionview 8.0.2
Installing rerun 0.14.0
Fetching actionpack 8.0.2
Installing actionpack 8.0.2
Fetching railties 8.0.2
Installing railties 8.0.2
Fetching rubocop-minitest 0.38.2
Fetching rubocop-performance 1.25.0
Installing rubocop-minitest 0.38.2
Installing rubocop-performance 1.25.0
Fetching rspec-rails 6.1.5
Installing rspec-rails 6.1.5
Fetching glogin 0.17.2
Installing glogin 0.17.2 will regenerate Gemfile.lock.