### PR TITLE
#311: update TargetRubyVersion to 3.3

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ AllCops:
     - 'assets/**/*'
     - 'vendor/**/*'
   DisplayCopNames: true
-  TargetRubyVersion: 2.6.0
+  TargetRubyVersion: 3.3
   NewCops: enable
   SuggestExtensions: false
 plugins:

--- a/Rakefile
+++ b/Rakefile
@@ -94,7 +94,7 @@ task(seed_dummy: %i[pgsql liquibase]) do
   require_relative 'objects/rsk'
   require_relative 'objects/triples'
   pgsql = Pgtk::Pool.new(Pgtk::Wire::Yaml.new('target/pgsql-config.yml'), log: Loog::NULL).start
-  fixtures = YAML.safe_load(File.read('liquibase/fixtures.yml'))
+  fixtures = YAML.safe_load_file('liquibase/fixtures.yml')
   fixtures.each do |key, data|
     login = "demo_#{key}"
     pid = Rsk::Projects.new(pgsql, login).add(data['title'])


### PR DESCRIPTION
Update .rubocop.yml to reflect the Ruby version actually used in CI (3.3).

Ruby 2.6 has been EOL since March 2022. The CI already runs on Ruby 3.3 (see .github/workflows/rake.yml). This change aligns the RuboCop configuration with reality.