### PR TITLE
#316: add telechats tests

### DIFF
--- a/test/test_telechats.rb
+++ b/test/test_telechats.rb
@@ -21,4 +21,33 @@ class Rsk::TelechatsTest < Minitest::Test
     refute(telechats.diff?(msg, chat))
     assert(telechats.diff?('something else', chat))
   end
+
+  def test_adds_and_fetches
+    login = "judyAF#{rand(99_999)}"
+    telechats = Rsk::Telechats.new(test_pgsql)
+    chat = rand(99_999)
+    telechats.add(chat, login)
+    assert(telechats.exists?(chat))
+    assert_equal(login, telechats.login_of(chat))
+    assert_equal(chat, telechats.chat_of(login))
+  end
+
+  def test_wired
+    login = "judyW#{rand(99_999)}"
+    telechats = Rsk::Telechats.new(test_pgsql)
+    chat = rand(99_999)
+    refute(telechats.wired?(login))
+    telechats.add(chat, login)
+    assert(telechats.wired?(login))
+  end
+
+  def test_double_add
+    login = "judyDA#{rand(99_999)}"
+    telechats = Rsk::Telechats.new(test_pgsql)
+    chat = rand(99_999)
+    telechats.add(chat, login)
+    assert_raises(PG::UniqueViolation) do
+      telechats.add(chat, 'other')
+    end
+  end
 end


### PR DESCRIPTION
Adds tests for Rsk::Telechats:

- test_adds_and_fetches — add, exists?, login_of, chat_of
- test_wired — wired? before and after add
- test_double_add — duplicate chat_id raises PG::UniqueViolation