### PR TITLE
#317: fix race condition in test_pgsql

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -41,6 +41,8 @@ Metrics/ParameterLists:
   Max: 10
 Layout/ParameterAlignment:
   Enabled: false
+Layout/ArgumentAlignment:
+  Enabled: false
 Metrics/PerceivedComplexity:
   Max: 25
 Layout/LineLength:

--- a/test/test__helper.rb
+++ b/test/test__helper.rb
@@ -39,12 +39,13 @@ require 'yaml'
 
 class Minitest::Test
   def test_pgsql
-    @@test_pgsql ||= Pgtk::Pool.new(
-      Pgtk::Wire::Yaml.new(File.join(__dir__, '../target/pgsql-config.yml')),
-      log: Loog::NULL
-    )
-    @@test_pgsql.start!
-    @@test_pgsql
+    @@test_pgsql_mutex ||= Mutex.new
+    @@test_pgsql_mutex.synchronize do
+      @@test_pgsql ||= Pgtk::Pool.new(
+        Pgtk::Wire::Yaml.new(File.join(__dir__, '../target/pgsql-config.yml')),
+        log: Loog::NULL
+      ).start
+    end
     # rubocop:enable Style/ClassVars
   end
 end

--- a/test/test__helper.rb
+++ b/test/test__helper.rb
@@ -39,8 +39,8 @@ require 'yaml'
 
 class Minitest::Test
   def test_pgsql
-    @@test_pgsql_mutex ||= Mutex.new
-    @@test_pgsql_mutex.synchronize do
+    @@mtx ||= Mutex.new
+    @@mtx.synchronize do
       @@test_pgsql ||= Pgtk::Pool.new(
         Pgtk::Wire::Yaml.new(File.join(__dir__, '../target/pgsql-config.yml')),
         log: Loog::NULL

--- a/test/test__helper.rb
+++ b/test/test__helper.rb
@@ -44,8 +44,10 @@ class Minitest::Test
       @@test_pgsql ||= Pgtk::Pool.new(
         Pgtk::Wire::Yaml.new(File.join(__dir__, '../target/pgsql-config.yml')),
         log: Loog::NULL
-      ).start
+      )
+      @@test_pgsql.start!
     end
+    @@test_pgsql
     # rubocop:enable Style/ClassVars
   end
 end

--- a/test/test_telechats.rb
+++ b/test/test_telechats.rb
@@ -5,12 +5,13 @@
 
 require_relative 'test__helper'
 
+require 'securerandom'
 require_relative '../objects/telechats'
 
 class Rsk::TelechatsTest < Minitest::Test
   def test_checks
     telechats = Rsk::Telechats.new(test_pgsql)
-    chat = rand(99_999)
+    chat = SecureRandom.random_number(2_000_000_000) + 1
     telechats.add(chat, "judy#{rand(99_999)}")
     msg = 'hey, you!'
     telechats.posted(msg, chat)
@@ -21,27 +22,25 @@ class Rsk::TelechatsTest < Minitest::Test
   def test_adds_and_fetches
     login = "judyAF#{rand(99_999)}"
     telechats = Rsk::Telechats.new(test_pgsql)
-    chat = rand(99_999)
+    chat = SecureRandom.random_number(2_000_000_000) + 1
     telechats.add(chat, login)
     assert(telechats.exists?(chat))
-    assert_equal(login, telechats.login_of(chat))
-    assert_equal(chat, telechats.chat_of(login))
+    assert_equal(login, telechats.login(chat))
+    assert_equal(chat, telechats.chat(login))
   end
 
   def test_wired
     login = "judyW#{rand(99_999)}"
     telechats = Rsk::Telechats.new(test_pgsql)
-    chat = rand(99_999)
     refute(telechats.wired?(login))
-    telechats.add(chat, login)
+    telechats.add(SecureRandom.random_number(2_000_000_000) + 1, login)
     assert(telechats.wired?(login))
   end
 
   def test_double_add
-    login = "judyDA#{rand(99_999)}"
     telechats = Rsk::Telechats.new(test_pgsql)
-    chat = rand(99_999)
-    telechats.add(chat, login)
+    chat = SecureRandom.random_number(2_000_000_000) + 1
+    telechats.add(chat, "judyDA#{rand(99_999)}")
     assert_raises(PG::UniqueViolation) do
       telechats.add(chat, 'other')
     end

--- a/test/test_telechats.rb
+++ b/test/test_telechats.rb
@@ -17,4 +17,33 @@ class Rsk::TelechatsTest < Minitest::Test
     refute(telechats.diff?(msg, chat))
     assert(telechats.diff?('something else', chat))
   end
+
+  def test_adds_and_fetches
+    login = "judyAF#{rand(99_999)}"
+    telechats = Rsk::Telechats.new(test_pgsql)
+    chat = rand(99_999)
+    telechats.add(chat, login)
+    assert(telechats.exists?(chat))
+    assert_equal(login, telechats.login_of(chat))
+    assert_equal(chat, telechats.chat_of(login))
+  end
+
+  def test_wired
+    login = "judyW#{rand(99_999)}"
+    telechats = Rsk::Telechats.new(test_pgsql)
+    chat = rand(99_999)
+    refute(telechats.wired?(login))
+    telechats.add(chat, login)
+    assert(telechats.wired?(login))
+  end
+
+  def test_double_add
+    login = "judyDA#{rand(99_999)}"
+    telechats = Rsk::Telechats.new(test_pgsql)
+    chat = rand(99_999)
+    telechats.add(chat, login)
+    assert_raises(PG::UniqueViolation) do
+      telechats.add(chat, 'other')
+    end
+  end
 end

--- a/test/test_telepings.rb
+++ b/test/test_telepings.rb
@@ -5,6 +5,7 @@
 
 require_relative 'test__helper'
 
+require 'securerandom'
 require_relative '../objects/causes'
 require_relative '../objects/effects'
 require_relative '../objects/plans'
@@ -28,7 +29,7 @@ class Rsk::TelepingsTest < Minitest::Test
   def test_adds
     login = "judyTA#{rand(99_999)}"
     tasks = test_tasks(login)
-    chat = rand(99_999)
+    chat = SecureRandom.random_number(2_000_000_000) + 1
     Rsk::Telechats.new(test_pgsql).add(chat, login)
     telepings = Rsk::Telepings.new(test_pgsql)
     refute_empty(telepings.fresh(login))


### PR DESCRIPTION
Wrap `@@test_pgsql` initialization in a `Mutex#synchronize` to prevent two threads from both creating a pool when the class variable is nil.