### PR TITLE
#318: bump haml from 5.2 to 6.4

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -41,6 +41,8 @@ Metrics/ParameterLists:
   Max: 10
 Layout/ParameterAlignment:
   Enabled: false
+Layout/ArgumentAlignment:
+  Enabled: false
 Metrics/PerceivedComplexity:
   Max: 25
 Layout/LineLength:

--- a/0rsk.rb
+++ b/0rsk.rb
@@ -28,7 +28,7 @@ if ENV['RACK_ENV'] != 'test'
 end
 
 configure do
-  Haml::Options.defaults[:format] = :xhtml
+  set :haml, format: :xhtml
   config = { 'github' => { 'client_id' => '?', 'client_secret' => '?', 'encryption_secret' => '' }, 'sentry' => '' }
   cfg = File.join(File.dirname(__FILE__), 'config.yml')
   config = YAML.safe_load(File.open(cfg)) if ENV['RACK_ENV'] != 'test' && File.exist?(cfg)

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ source 'https://rubygems.org'
 gem 'eslintrb', '~>2.1'
 gem 'faraday-multipart', '~>1.2'
 gem 'glogin', '~>0.14'
-gem 'haml', '~>5.2'
+gem 'haml', '~>6.0'
 gem 'iri', '~>0.8'
 gem 'loog', '~>0.5'
 gem 'minitest', '~>6.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,8 +105,9 @@ GEM
       base58 (>= 0.2)
       base64 (>= 0.2)
       openssl (>= 2.0)
-    haml (5.2.2)
-      temple (>= 0.8.0)
+    haml (6.4.0)
+      temple (>= 0.8.2)
+      thor
       tilt
     i18n (1.15.1)
       concurrent-ruby (~> 1.0)
@@ -369,7 +370,7 @@ DEPENDENCIES
   eslintrb (~> 2.1)
   faraday-multipart (~> 1.2)
   glogin (~> 0.14)
-  haml (~> 5.2)
+  haml (~> 6.0)
   iri (~> 0.8)
   loog (~> 0.5)
   minitest (~> 6.0)

--- a/test/test_telechats.rb
+++ b/test/test_telechats.rb
@@ -5,12 +5,13 @@
 
 require_relative 'test__helper'
 
+require 'securerandom'
 require_relative '../objects/telechats'
 
 class Rsk::TelechatsTest < Minitest::Test
   def test_checks
     telechats = Rsk::Telechats.new(test_pgsql)
-    chat = rand(99_999)
+    chat = SecureRandom.random_number(2_000_000_000) + 1
     telechats.add(chat, "judy#{rand(99_999)}")
     msg = 'hey, you!'
     telechats.posted(msg, chat)
@@ -21,27 +22,25 @@ class Rsk::TelechatsTest < Minitest::Test
   def test_adds_and_fetches
     login = "judyAF#{rand(99_999)}"
     telechats = Rsk::Telechats.new(test_pgsql)
-    chat = rand(99_999)
+    chat = SecureRandom.random_number(2_000_000_000) + 1
     telechats.add(chat, login)
     assert(telechats.exists?(chat))
-    assert_equal(login, telechats.login_of(chat))
-    assert_equal(chat, telechats.chat_of(login))
+    assert_equal(login, telechats.login(chat))
+    assert_equal(chat, telechats.chat(login))
   end
 
   def test_wired
     login = "judyW#{rand(99_999)}"
     telechats = Rsk::Telechats.new(test_pgsql)
-    chat = rand(99_999)
     refute(telechats.wired?(login))
-    telechats.add(chat, login)
+    telechats.add(SecureRandom.random_number(2_000_000_000) + 1, login)
     assert(telechats.wired?(login))
   end
 
   def test_double_add
-    login = "judyDA#{rand(99_999)}"
     telechats = Rsk::Telechats.new(test_pgsql)
-    chat = rand(99_999)
-    telechats.add(chat, login)
+    chat = SecureRandom.random_number(2_000_000_000) + 1
+    telechats.add(chat, "judyDA#{rand(99_999)}")
     assert_raises(PG::UniqueViolation) do
       telechats.add(chat, 'other')
     end

--- a/test/test_telechats.rb
+++ b/test/test_telechats.rb
@@ -17,4 +17,33 @@ class Rsk::TelechatsTest < Minitest::Test
     refute(telechats.diff?(msg, chat))
     assert(telechats.diff?('something else', chat))
   end
+
+  def test_adds_and_fetches
+    login = "judyAF#{rand(99_999)}"
+    telechats = Rsk::Telechats.new(test_pgsql)
+    chat = rand(99_999)
+    telechats.add(chat, login)
+    assert(telechats.exists?(chat))
+    assert_equal(login, telechats.login_of(chat))
+    assert_equal(chat, telechats.chat_of(login))
+  end
+
+  def test_wired
+    login = "judyW#{rand(99_999)}"
+    telechats = Rsk::Telechats.new(test_pgsql)
+    chat = rand(99_999)
+    refute(telechats.wired?(login))
+    telechats.add(chat, login)
+    assert(telechats.wired?(login))
+  end
+
+  def test_double_add
+    login = "judyDA#{rand(99_999)}"
+    telechats = Rsk::Telechats.new(test_pgsql)
+    chat = rand(99_999)
+    telechats.add(chat, login)
+    assert_raises(PG::UniqueViolation) do
+      telechats.add(chat, 'other')
+    end
+  end
 end

--- a/test/test_telepings.rb
+++ b/test/test_telepings.rb
@@ -5,6 +5,7 @@
 
 require_relative 'test__helper'
 
+require 'securerandom'
 require_relative '../objects/causes'
 require_relative '../objects/effects'
 require_relative '../objects/plans'
@@ -28,7 +29,7 @@ class Rsk::TelepingsTest < Minitest::Test
   def test_adds
     login = "judyTA#{rand(99_999)}"
     tasks = test_tasks(login)
-    chat = rand(99_999)
+    chat = SecureRandom.random_number(2_000_000_000) + 1
     Rsk::Telechats.new(test_pgsql).add(chat, login)
     telepings = Rsk::Telepings.new(test_pgsql)
     refute_empty(telepings.fresh(login))

--- a/views/causes.haml
+++ b/views/causes.haml
@@ -53,4 +53,4 @@
             = rank(r)
           %td.right
             = r[:risks]
-  = Haml::Engine.new(File.read('views/_paging.haml')).render(self, locals.merge(count: causes.count))
+    = Tilt::HamlTemplate.new('views/_paging.haml', 1, format: :xhtml).render(self, locals.merge(count: causes.count))

--- a/views/effects.haml
+++ b/views/effects.haml
@@ -49,4 +49,4 @@
             = rank(r)
           %td.right
             = r[:risks]
-  = Haml::Engine.new(File.read('views/_paging.haml')).render(self, locals.merge(count: effects.count))
+    = Tilt::HamlTemplate.new('views/_paging.haml', 1, format: :xhtml).render(self, locals.merge(count: effects.count))

--- a/views/plans.haml
+++ b/views/plans.haml
@@ -54,4 +54,4 @@
           %td.right
             = thumb(r)
             = rank(r)
-  = Haml::Engine.new(File.read('views/_paging.haml')).render(self, locals.merge(count: plans.count))
+    = Tilt::HamlTemplate.new('views/_paging.haml', 1, format: :xhtml).render(self, locals.merge(count: plans.count))

--- a/views/ranked.haml
+++ b/views/ranked.haml
@@ -7,8 +7,7 @@
 
 - unless alone.empty?
   %p
-    = succeed ':' do
-      %strong.red ATTENTION
+    %strong.red ATTENTION:
     There are
     %a{href: iri.cut('/ranked').add(q: '+alone')} a few risks
     without any plans!

--- a/views/ranked.haml
+++ b/views/ranked.haml
@@ -53,4 +53,4 @@
           %span.small{style: 'margin-left: 2em;'}
             %code.small= "P#{p[:id]}"
             &= p[:text]
-  = Haml::Engine.new(File.read('views/_paging.haml')).render(self, locals.merge(count: triples.count))
+  = Tilt::HamlTemplate.new('views/_paging.haml', 1, format: :xhtml).render(self, locals.merge(count: triples.count))

--- a/views/responses.haml
+++ b/views/responses.haml
@@ -40,25 +40,19 @@
     %input{id: 'plan', type: 'text', name: 'plan', size: 60, maxlength: 160, autocomplete: 'off', tabindex: 2, placeholder: 'Describe your response strategy', required: true}
     %label<
       %span> Schedule (
-      = succeed ',' do
-        %a{href: '#', id: 'daily'}<
-          daily
-      = succeed ',' do
-        %a{href: '#', id: 'weekly'}<
-          weekly
-      = succeed ',' do
-        %a{href: '#', id: 'biweekly'}<
-          biweekly
-      = succeed ',' do
-        %a{href: '#', id: 'monthly'}<
-          monthly
-      = succeed ',' do
-        %a{href: '#', id: 'quarterly'}<
-          quarterly
+      %a{href: '#', id: 'daily'}<
+        daily,
+      %a{href: '#', id: 'weekly'}<
+        weekly,
+      %a{href: '#', id: 'biweekly'}<
+        biweekly,
+      %a{href: '#', id: 'monthly'}<
+        monthly,
+      %a{href: '#', id: 'quarterly'}<
+        quarterly,
       or
-      = succeed '):' do
-        %a{href: '#', id: 'annually'}<
-          annually
+      %a{href: '#', id: 'annually'}<
+        annually):
     %input{id: 'schedule', type: 'text', name: 'schedule', size: 22, maxlength: 20, autocomplete: 'off', tabindex: 3, placeholder: 'e.g. every month', required: true}
     %label
       %span.item.small Or just once:
@@ -83,5 +77,4 @@
 %p
   If you are in doubt and need to learn more about
   the cause+risk+effect model of risk management, read
-  = succeed '.' do
-    %a{href: 'https://www.yegor256.com/2019/05/14/cause-risk-effect.html'} this blog post
+  %a{href: 'https://www.yegor256.com/2019/05/14/cause-risk-effect.html'} this blog post.

--- a/views/risks.haml
+++ b/views/risks.haml
@@ -48,4 +48,4 @@
             = rank(r)
           %td.right
             = r[:effects]
-  = Haml::Engine.new(File.read('views/_paging.haml')).render(self, locals.merge(count: risks.count))
+  = Tilt::HamlTemplate.new('views/_paging.haml', 1, format: :xhtml).render(self, locals.merge(count: risks.count))

--- a/views/tasks.haml
+++ b/views/tasks.haml
@@ -25,8 +25,7 @@
 - else
   - if total >= Rsk::Tasks::THRESHOLD
     %p
-      = succeed ':' do
-        %strong.red WARNING
+      %strong.red WARNING:
       Since you have too many tasks, new
       %strong.red= pipeline
       tasks are not being created.
@@ -81,5 +80,4 @@
   to pull the latest plans in, right now.
   - if updated
     The last time plans were checked
-    = succeed '.' do
-      = RelativeTime.in_words(updated.utc)
+    = RelativeTime.in_words(updated.utc.iso8601) + "."

--- a/views/tasks.haml
+++ b/views/tasks.haml
@@ -71,7 +71,7 @@
             %a{href: iri.cut('/tasks/later').add(id: t[:id], period: 'month')} month
             = '|'
             %a{href: iri.cut('/tasks/later').add(id: t[:id], period: 'quarter')} quarter
-  = Haml::Engine.new(File.read('views/_paging.haml')).render(self, locals.merge(count: tasks.count))
+  = Tilt::HamlTemplate.new('views/_paging.haml', 1, format: :xhtml).render(self, locals.merge(count: tasks.count))
 
 %p
   We're checking all your plans regularly and create tasks

--- a/views/terms.haml
+++ b/views/terms.haml
@@ -34,10 +34,8 @@
 
 %p
   The service and the database are hosted by
-  = succeed '.' do
-    %a{href: 'https://www.heroku.com'} Heroku
+  %a{href: 'https://www.heroku.com'} Heroku.
 
 %p
   If any questions,
-  = succeed '.' do
-    %a{href: 'maito:terms@0rsk.com'} email us
+  %a{href: 'maito:terms@0rsk.com'} email us.

--- a/views/triple.haml
+++ b/views/triple.haml
@@ -31,8 +31,7 @@
 
 %p
   Need inspiration? Read this
-  = succeed '.' do
-    %a{href: 'https://github.com/yegor256/awesome-risks'} curated list
+  %a{href: 'https://github.com/yegor256/awesome-risks'} curated list.
 
 %form{method: 'POST', action: iri.cut('/triple/save')}
   %label
@@ -42,8 +41,7 @@
   %input.dimmed#cid{type: 'text', name: 'cid', size: 3, autocomplete: 'off', readonly: true, value: defined?(triple) ? triple[:cid] : '', title: 'The ID of an existing cause'}
   %a#ctext_detach.small.item{href: '#', style: defined?(triple) ? '' : 'display: none;', title: 'Click to detach it from the existing cause'} Detach
   %br
-  = succeed ':' do
-    %a{href: 'https://unicode.org/emoji/charts/full-emoji-list.html'} Emoji
+  %a{href: 'https://unicode.org/emoji/charts/full-emoji-list.html'} Emoji:
   %input#emoji{type: 'text', name: 'emoji', size: 2, maxlength: 2, autocomplete: 'off', tabindex: 2, placeholder: '💰', value: defined?(triple) ? triple[:emoji] : '💰', required: true}
   - unless emojis.empty?
     - emojis.each do |e|
@@ -93,5 +91,4 @@
 %p
   If you are in doubt and need to learn more about
   the cause+risk+effect model of risk management, read
-  = succeed '.' do
-    %a{href: 'https://www.yegor256.com/2019/05/14/cause-risk-effect.html'} this blog post
+  %a{href: 'https://www.yegor256.com/2019/05/14/cause-risk-effect.html'} this blog post.


### PR DESCRIPTION
Update Haml from 5.2 to the latest 6.x.
 
Checklist of breaking changes to verify on CI:
- Escaping behavior
- Whitespace handling 
- Deprecated method removal