### PR TITLE
#320: add Dockerfile and docker-compose.yml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+FROM ruby:3.3-slim
+
+RUN apt-get update && apt-get install -y postgresql-client libpq-dev && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+
+COPY . .
+
+EXPOSE 9292
+
+CMD ["bundle", "exec", "ruby", "0rsk.rb", "-p", "9292"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+services:
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: 0rsk
+      POSTGRES_USER: test
+      POSTGRES_PASSWORD: test
+    ports:
+      - 5432:5432
+    healthcheck:
+      test: pg_isready -U test -d 0rsk
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  app:
+    build: .
+    ports:
+      - 9292:9292
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgres://test:test@db:5432/0rsk
+    volumes:
+      - ./config.yml:/app/config.yml


### PR DESCRIPTION
Adds Docker support for local development:

- `Dockerfile` based on ruby:3.3-slim with PostgreSQL client
- `docker-compose.yml` with PostgreSQL 16 and app service

Usage:
```
docker compose up
```
Create `config.yml` with GitHub OAuth credentials before starting.