### PR TITLE
#326: bump faraday-multipart 1.1.0→1.2.0 for Ruby 4 compat

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@
 source 'https://rubygems.org'
 
 gem 'eslintrb', '~>2.1'
+gem 'faraday-multipart', '~>1.2'
 gem 'glogin', '~>0.14'
 gem 'haml', '~>5.2'
 gem 'iri', '~>0.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,7 +83,7 @@ GEM
     faraday-em_synchrony (1.0.0)
     faraday-excon (1.1.0)
     faraday-httpclient (1.0.1)
-    faraday-multipart (1.1.0)
+    faraday-multipart (1.2.0)
       multipart-post (~> 2.0)
     faraday-net_http (1.0.2)
     faraday-net_http_persistent (1.2.0)
@@ -351,6 +351,7 @@ PLATFORMS
 
 DEPENDENCIES
   eslintrb (~> 2.1)
+  faraday-multipart (~> 1.2)
   glogin (~> 0.14)
   haml (~> 5.2)
   iri (~> 0.8)


### PR DESCRIPTION
## Problem

CI on master fails with:

```
faraday-multipart-1.1.0 requires ruby version < 4, >= 2.4, which is incompatible
with the current version, 4.0.5
```

GitHub Actions runners now use Ruby 4.0.5, but `faraday-multipart 1.1.0` has a required Ruby version constraint `< 4`, making `bundle install` fail immediately.

## Root Cause

- `faraday-multipart 1.1.0` declares `required_ruby_version = [">= 2.4", "< 4"]`
- Ruby 4.0.5 violates the `< 4` constraint
- This is transitive: `faraday ~> 1.10` depends on `faraday-multipart ~> 1.0`, locking at 1.1.0

## Solution

Bump `faraday-multipart` to `~> 1.2` (1.2.0, released Dec 2025), which drops the `< 4` constraint:

```
faraday-multipart 1.2.0 requires ruby version >= 2.4 (no upper bound)
```

Changes:
- `Gemfile`: added explicit `gem 'faraday-multipart', '~>1.2'`
- `Gemfile.lock`: `faraday-multipart 1.1.0` → `1.2.0`

No other dependencies changed.