### PR TITLE
#13 add alt attribute to all img elements

### DIFF
--- a/front/front_helpers.rb
+++ b/front/front_helpers.rb
@@ -9,7 +9,8 @@ helpers do
   end
 
   def thumb(i)
-    "<img class='#{i[:positive] ? 'up' : 'down'}'/>"
+    direction = i[:positive] ? 'up' : 'down'
+    "<img class='#{direction}' alt='#{direction}'/>"
   end
 
   def rank(i)

--- a/views/layout.haml
+++ b/views/layout.haml
@@ -82,7 +82,7 @@
                 %li
                   %a{href: iri.cut('/plans')} Plans
               %li
-                %img{src: iri.cut('/telegram-logo.svg'), style: 'height: 1.1em; vertical-align: middle;'}
+                %img{src: iri.cut('/telegram-logo.svg'), alt: 'Telegram', style: 'height: 1.1em; vertical-align: middle;'}
                 %a{href: 'https://t.me/zerorsk_bot'} Talk to me
         %nav
           %ul

--- a/views/triple.haml
+++ b/views/triple.haml
@@ -6,7 +6,7 @@
 %script{src: '/js/triple.js'}
 
 %div.small.right{style: 'float:right; width:200px;'}
-  %img{src: '/dont-talk.png', style: 'width: 120px;'}
+  %img{src: '/dont-talk.png', alt: "Don't talk", style: 'width: 120px;'}
   %br
   Cause: The data you enter
   %strong is
@@ -84,9 +84,9 @@
     - {'Fantastic' => 9, 'Awesome' => 8, 'Very good' => 6, 'Average' => 5, 'Good to have' => 4, 'Minor' => 2, 'Unnoticeable' => 1}.each do |k, v|
       %option{value: v, selected: defined?(triple) && triple[:impact] == v, type: 'positive', hidden: !defined?(triple) || !triple[:positive]}= "#{k} (#{v})"
   - if defined?(triple) && triple[:positive]
-    %img#marker.up
+    %img#marker.up{alt: 'up'}
   - else
-    %img#marker.down
+    %img#marker.down{alt: 'down'}
   %br
   %input{type: 'submit', value: 'Submit', tabindex: 8, onclick: 'if ($("#cid").val() || $("#rid").val() || $("#eid").val()) { return confirm("You are going to MODIFY existing data, are you sure?"); }'}
 


### PR DESCRIPTION
The HAML views and one HTML helper emit `<img>` elements without an `alt` attribute, which fails the request in issue #13 to give every image an `alt`. The four missing locations are the Telegram logo in the footer, the warning image at the top of the triple form, the two impact markers below the impact select, and the inline thumb helper used in ranked rows.

Each `<img>` now carries an `alt`: `Telegram` for the footer logo, `Don't talk` for the warning image, and `up` or `down` for the markers and the thumb helper, the same string the CSS already uses through the `.up` and `.down` classes. The thumb helper extracts the direction into a local to keep the two interpolations in sync.

Ran `bundle install` against Ruby 3.3.6, `bundle exec rubocop front/front_helpers.rb` (no offenses), and parsed both edited templates with `Haml::Engine.new(File.read(path, encoding: 'utf-8'))` (both ok). The full `bundle exec rake` was not run because the test suite expects a PostgreSQL instance prepared by `dockers/extras/install-postgres.sh` that is unavailable in this environment; CI on the pull request will cover it.

Closes #13
