### PR TITLE
#235: fix String#to_time error in RelativeTime.in_words calls

### DIFF
--- a/views/plans.haml
+++ b/views/plans.haml
@@ -50,7 +50,7 @@
           %td
             = r[:schedule]
           %td
-            = RelativeTime.in_words(r[:completed].utc.iso8601)
+            = RelativeTime.in_words(r[:completed].utc)
           %td.right
             = thumb(r)
             = rank(r)

--- a/views/tasks.haml
+++ b/views/tasks.haml
@@ -82,4 +82,4 @@
   - if updated
     The last time plans were checked
     = succeed '.' do
-      = RelativeTime.in_words(updated.utc.iso8601)
+      = RelativeTime.in_words(updated.utc)


### PR DESCRIPTION
Fixes #235

## Problem
When viewing plans page, an internal error occurs: `undefined method to_time for "2025-09-07T15:19:27Z":String`

RelativeTime::InWords#call calls `.to_time` on its arguments, expecting Time/DateTime — but the template passes a string via `.iso8601`. `String#to_time` is not a core Ruby method (ActiveSupport), so it fails.

## Fix
Remove `.iso8601` — pass the Time object directly. RelativeTime.in_words already handles Time/DateTime via `.to_time`.

## Files
- `views/plans.haml:53`: `.iso8601` removed
- `views/tasks.haml:85`: `.iso8601` removed (same bug, unreported)
