### PR TITLE
#11: notify via Telegram about triples without response plans

### DIFF
--- a/front/front_telegram.rb
+++ b/front/front_telegram.rb
@@ -149,6 +149,26 @@ module Rsk::Telegram
     end
   end
 
+  def alone
+    users.fetch.each do |login|
+      next unless telechats.wired?(login)
+      chat = telechats.chat(login)
+      Rsk::Projects.new(settings.pgsql, login).fetch.each do |project|
+        count = Rsk::Triples.new(settings.pgsql, project[:id]).count(query: '+alone')
+        next if count.zero?
+        msg = [
+          "You have #{count} risk#{'s' unless count == 1} without response",
+          "plan#{'s' unless count == 1} in project '#{project[:title]}'.",
+          '[View them](https://www.0rsk.com/ranked?q=%2Balone).'
+        ].join(' ')
+        telepost(msg, chat) if telechats.diff?(msg, chat)
+      end
+    rescue StandardError => e
+      settings.log.error(e.message)
+      next
+    end
+  end
+
   def listing(list)
     if list.count < 8
       [
@@ -203,5 +223,11 @@ end
 if settings.config['telegram']
   Rsk::Daemon.new(10).start do
     broadcast
+  end
+end
+
+if settings.config['telegram']
+  Rsk::Daemon.new(1440).start do
+    alone
   end
 end


### PR DESCRIPTION
Fixes #11

## Problem
Users who have risks (triples) without any response plans don't get reminded to add plans. They may forget about risks that need mitigation strategies.

## Solution
Every 24 hours, check each user's projects for triples without plans (using the existing `+alone` query) and send a Telegram notification if any are found.

## Implementation
One file changed: `front/front_telegram.rb`

- Added `notify_alone` method: iterates over all users with Telegram connected, checks each project for triples without plans, sends a summary message with count and a link to `/ranked?q=%2Balone`
- Added a daemon with 1440-minute (24h) interval that calls `notify_alone`
- Follows the same patterns as the existing `notify_all` (error handling, logging, `telepost`/`telechats.diff?` dedup)

## Message format
```
You have 3 risks without response plans in project 'My Project'. View them.
```

The link opens the ranked page filtered to show only triples without plans.

## CI
Awaiting CI run.
