### PR TITLE
#12: add title HTML attribute to all links

### DIFF
--- a/views/_paging.haml
+++ b/views/_paging.haml
@@ -4,12 +4,12 @@
 - if offset > 0 || total > limit
   %p.small
     - if offset.positive?
-      %a.item{href: iri.over(offset: offset - limit)} Previous
+      %a.item{href: iri.over(offset: offset - limit), title: "Previous page"} Previous
     - else
       %span.item Pages:
     - current = (offset / limit).floor
     - (0..((total - 1) / limit).floor).each do |p|
       - next if p < current - 5 || p > current + 5
-      %a.item{href: iri.over(offset: p * limit), style: p == current ? 'font-weight:bold' : ''}= p + 1
+      %a.item{href: iri.over(offset: p * limit), style: p == current ? 'font-weight:bold' : '', title: "Page #{p + 1}"}= p + 1
     - if count >= limit
-      %a.item{href: iri.over(offset: offset + limit)} Next
+      %a.item{href: iri.over(offset: offset + limit), title: "Next page"} Next

--- a/views/causes.haml
+++ b/views/causes.haml
@@ -10,7 +10,7 @@
 
 %p{style: 'font-size: 1.4em;'}
   - emojis.each do |e|
-    %a{href: iri.cut('/causes').add(q: e)}= e
+    %a{href: iri.cut('/causes').add(q: e), title: "Filter by #{e}"}= e
 
 - if causes.empty?
   - if query.empty?
@@ -45,7 +45,7 @@
           %td
             = part('C', r[:id])
           %td
-            %a{href: iri.cut('/causes').add(q: r[:emoji])}<
+            %a{href: iri.cut('/causes').add(q: r[:emoji]), title: 'Filter'}<
               &= r[:emoji]
           %td
             &= r[:text]

--- a/views/error.haml
+++ b/views/error.haml
@@ -8,7 +8,7 @@
 %p
   Please help us improve our service and submit the following
   stacktrace to our issue tracker in GitHub:
-  %a{href:'https://github.com/yegor256/0rsk'} yegor256/0rsk
+  %a{href:'https://github.com/yegor256/0rsk', title: 'GitHub repository'} yegor256/0rsk
 
 %pre
   &=error

--- a/views/index.haml
+++ b/views/index.haml
@@ -13,14 +13,14 @@
 
 %p
   Read this blog post before you start using it:
-  %a{href: 'https://www.yegor256.com/2019/05/14/cause-risk-effect.html'} 0rsk.com: Cause + Risk + Effect
+  %a{href: 'https://www.yegor256.com/2019/05/14/cause-risk-effect.html', title: 'Learn about C+R+E model'} 0rsk.com: Cause + Risk + Effect
 
 %p
   You may also want to watch
-  %a{href: 'https://youtu.be/WlI6IZ6M7vY'} this video
+  %a{href: 'https://youtu.be/WlI6IZ6M7vY', title: 'Watch video'} this video
   first.
 
 %p
   Also, check this
-  %a{href: 'https://github.com/yegor256/awesome-risks'} curated list
+  %a{href: 'https://github.com/yegor256/awesome-risks', title: 'Risk examples'} curated list
   of causes, risks, and effects.

--- a/views/layout.haml
+++ b/views/layout.haml
@@ -45,26 +45,25 @@
         %nav
           %ul
             %li
-              %a{href: url('/')}
+              %a{href: url('/'), title: 'Home'}
                 %img.logo{src: iri.cut('/logo.svg'), alt: 'Logo'}
         %nav
           %ul
             %li
               - if defined?(user)
-                %a{href: '/projects'}= "@#{user[:login]}"
+                %a{href: '/projects', title: 'Your projects'}= "@#{user[:login]}"
                 - if request.cookies['0rsk-project']
                   = '/'
-                  %a{href: iri.cut('/project').append(pid)}= "##{pid}"
+                  %a{href: iri.cut('/project').append(pid), title: 'View project'}= "##{pid}"
               - else
-                %a{href: login_link}
+                %a{href: login_link, title: 'Login with GitHub'}
                   Login
             - if defined?(user)
               %li
-                %a{href: iri.cut('/triple')}
+                %a{href: iri.cut('/triple'), title: 'New risk triple'}
                   Add
               %li
                 %a{href: iri.cut('/tasks'), title: 'Your tasks'}
-                  Tasks
                   - if tasks_count.zero?
                     (0)
                   - else
@@ -72,7 +71,7 @@
                       = "(#{tasks_count})"
               %li
                 %form{action: iri.cut('/logout'), method: 'POST', style: 'display:inline'}
-                  %button{type: 'submit', style: 'background:none;border:none;padding:0;color:inherit;font:inherit;cursor:pointer'}
+                  %button{type: 'submit', title: 'Logout', style: 'background:none;border:none;padding:0;color:inherit;font:inherit;cursor:pointer'}
                     Logout
         - if defined?(flash_msg) && !flash_msg.empty?
           %p{style: 'background-color:' + flash_color + ';color:white;padding:.1em .5em;border-radius:4px;width:100%;'}
@@ -84,27 +83,27 @@
           %nav
             %ul
               %li
-                %a{href: iri.cut('/projects')}
+                %a{href: iri.cut('/projects'), title: 'Your projects'}
                   Projects
               - if request.cookies['0rsk-project']
                 %li
-                  %a{href: iri.cut('/causes')} Causes
+                  %a{href: iri.cut('/causes'), title: 'Browse causes'} Causes
                 %li
-                  %a{href: iri.cut('/risks')} Risks
+                  %a{href: iri.cut('/risks'), title: 'Browse risks'} Risks
                 %li
-                  %a{href: iri.cut('/effects')} Effects
+                  %a{href: iri.cut('/effects'), title: 'Browse effects'} Effects
                 %li
-                  %a{href: iri.cut('/plans')} Plans
+                  %a{href: iri.cut('/plans'), title: 'Browse plans'} Plans
               %li
-                %img{src: iri.cut('/telegram-logo.svg'), alt: 'Telegram', style: 'height: 1.1em; vertical-align: middle;'}
-                %a{href: 'https://t.me/zerorsk_bot'} Talk to me
+              %img{src: iri.cut('/telegram-logo.svg'), alt: 'Telegram', style: 'height: 1.1em; vertical-align: middle;'}
+              %a{href: 'https://t.me/zerorsk_bot', title: 'Telegram bot'} Talk to me
         %nav
           %ul
             %li
               &copy; 2019
-              %a{href: 'https://www.zerocracy.com'} Zerocracy
+              %a{href: 'https://www.zerocracy.com', title: 'Zerocracy website'} Zerocracy
             %li
-              %a{href: iri.cut('/terms')} Terms of Use
+              %a{href: iri.cut('/terms'), title: 'Terms of use'} Terms of Use
         %nav
           %ul
             %li{title: 'Heroku release version and currently deployed version'}
@@ -112,15 +111,15 @@
             %li{title: 'PostgreSQL version'}
               = "pg:#{settings.pgsql.version}"
             %li{title: 'Your IP address visible to the server'}
-              %a{href: 'https://iplocation.com/?ip=' + request_ip}
+              %a{href: 'https://iplocation.com/?ip=', title: 'Your IP address' + request_ip}
                 = request_ip
             %li{title: 'This request processing time'}
               = "#{((Time.now - http_start) * 1000).round}ms"
         %nav
           %ul
             %li
-              %a{href: 'https://github.com/yegor256/0rsk/stargazers'}<
+              %a{href: 'https://github.com/yegor256/0rsk/stargazers', title: 'GitHub stars'}<
                 %img{src: 'https://img.shields.io/github/stars/yegor256/0rsk.svg?style=flat-square', alt: 'GitHub'}
             %li
-              %a{href: 'https://www.sixnines.io/h/6ea3'}<
+              %a{href: 'https://www.sixnines.io/h/6ea3', title: 'Uptime status'}<
                 %img{src: 'https://www.sixnines.io/b/6ea3?style=flat', alt: 'SixNines'}

--- a/views/plans.haml
+++ b/views/plans.haml
@@ -43,7 +43,7 @@
           %td
             %code= "P#{r[:id]}"
           %td
-            %a{href: iri.cut('/responses').add(id: r[:triple])}<
+            %a{href: iri.cut('/responses'), title: 'View responses'.add(id: r[:triple])}<
               %code= "#{r[:prefix]}#{r[:part]}"
           %td
             &= r[:text]

--- a/views/project.haml
+++ b/views/project.haml
@@ -10,7 +10,7 @@
 
 %p
   See
-  %a{href: iri.cut('/projects')} all projects
+  %a{href: iri.cut('/projects'), title: 'Your projects'} all projects
 
 %h3 Trackers
 

--- a/views/projects.haml
+++ b/views/projects.haml
@@ -24,5 +24,5 @@
       %br
       %span.small
         %form{action: iri.cut('/projects/delete').add(id: p[:id]), method: 'POST', style: 'display:inline', onsubmit: "return confirm('Are sure you want to delete it?')"}
-  %button{type: 'submit', style: 'background:none;border:none;padding:0;color:inherit;font:inherit;cursor:pointer'}
+  %button{type: 'submit', title: 'Delete project', style: 'background:none;border:none;padding:0;color:inherit;font:inherit;cursor:pointer'}
     Delete

--- a/views/ranked.haml
+++ b/views/ranked.haml
@@ -9,7 +9,7 @@
   %p
     %strong.red ATTENTION:
     There are
-    %a{href: iri.cut('/ranked').add(q: '+alone')} a few risks
+    %a{href: iri.cut('/ranked').add(q: '+alone'), title: 'Risks without plans'} a few risks
     without any plans!
 
 - if triples.empty?
@@ -25,7 +25,7 @@
     %p
       = thumb(r)
       = rank(r)
-      %a{href: iri.over(q: r[:emoji])}<
+      %a{href: iri.over(q: r[:emoji]), title: "Filter by #{r[:emoji]}"}<
         &= r[:emoji]
       = part('C', r[:cid])
       ➜
@@ -37,15 +37,15 @@
       &= "#{r[:rtext]};"
       &= "#{r[:etext]}."
       %br
-      %a.item.small{href: iri.cut('/triple').add(id: r[:id])} Edit
-      %a.item.small{href: iri.cut('/responses').add(id: r[:id])}<
+      %a.item.small{href: iri.cut('/triple').add(id: r[:id]), title: 'Edit triple'} Edit
+      %a.item.small{href: iri.cut('/responses').add(id: r[:id]), title: 'View responses'}<
         - if r[:plans].empty?
           %span.red No plans
         - else
           = "#{r[:plans].count} plan#{r[:plans].count == 1 ? '' : 's'}"
           = '&darr;'
       %form{action: iri.cut('/ranked/delete').add(id: r[:id]), method: 'POST', style: 'display:inline', onsubmit: "return confirm('Are sure you want to delete triple ##{r[:id]}?')"}
-        %button{type: 'submit', style: 'background:none;border:none;padding:0;color:inherit;font:inherit;cursor:pointer'}
+        %button{type: 'submit', title: 'Delete triple', style: 'background:none;border:none;padding:0;color:inherit;font:inherit;cursor:pointer'}
           Delete
       - unless r[:plans].empty?
         - r[:plans].each do |p|

--- a/views/responses.haml
+++ b/views/responses.haml
@@ -6,7 +6,7 @@
 
 %h2
   Responses to
-  %a{href: iri.cut('/triple').add(id: triple[:id])}
+  %a{href: iri.cut('/triple'), title: 'New risk triple'.add(id: triple[:id])}
     = "##{triple[:id]}"
 
 %p
@@ -40,26 +40,26 @@
     %input{id: 'plan', type: 'text', name: 'plan', size: 60, maxlength: 160, autocomplete: 'off', tabindex: 2, placeholder: 'Describe your response strategy', required: true}
     %label<
       %span> Schedule (
-      %a{href: '#', id: 'daily'}<
+      %a{href: '#', id: 'daily', title: 'Daily schedule'}<
         daily,
-      %a{href: '#', id: 'weekly'}<
+      %a{href: '#', id: 'weekly', title: 'Weekly schedule'}<
         weekly,
-      %a{href: '#', id: 'biweekly'}<
+      %a{href: '#', id: 'biweekly', title: 'Biweekly schedule'}<
         biweekly,
-      %a{href: '#', id: 'monthly'}<
+      %a{href: '#', id: 'monthly', title: 'Monthly schedule'}<
         monthly,
-      %a{href: '#', id: 'quarterly'}<
+      %a{href: '#', id: 'quarterly', title: 'Quarterly schedule'}<
         quarterly,
       or
-      %a{href: '#', id: 'annually'}<
+      %a{href: '#', id: 'annually', title: 'Annual schedule'}<
         annually):
     %input{id: 'schedule', type: 'text', name: 'schedule', size: 22, maxlength: 20, autocomplete: 'off', tabindex: 3, placeholder: 'e.g. every month', required: true}
     %label
       %span.item.small Or just once:
-      %a.item.small{href: '#', id: 'schedule_asap'} ASAP
-      %a.item.small{href: '#', id: 'schedule_week'} This week
-      %a.item.small{href: '#', id: 'schedule_month'} This month
-      %a.item.small{href: '#', id: 'schedule_later'} Later
+      %a.item.small{href: '#', id: 'schedule_asap', title: 'Schedule for today'} ASAP
+      %a.item.small{href: '#', id: 'schedule_week', title: 'Schedule for this week'} This week
+      %a.item.small{href: '#', id: 'schedule_month', title: 'Schedule for this month'} This month
+      %a.item.small{href: '#', id: 'schedule_later', title: 'Schedule for later'} Later
     %input{type: 'submit', value: 'Add', tabindex: 4}
 
 - plans.each do |p|
@@ -72,9 +72,9 @@
     %br
     %span.item.small
       &= p[:schedule]
-    %a.item.small{href: iri.cut('/responses/detach').add(tid: triple[:id], id: p[:id], part: p[:part]), onclick: "return confirm('Are sure you want to detach plan ##{p[:id]}');"} Detach
+    %a.item.small{href: iri.cut('/responses/detach').add(tid: triple[:id], id: p[:id], part: p[:part]), title: 'Detach plan', onclick: "return confirm('Are sure you want to detach plan ##{p[:id]}');"} Detach
 
 %p
   If you are in doubt and need to learn more about
   the cause+risk+effect model of risk management, read
-  %a{href: 'https://www.yegor256.com/2019/05/14/cause-risk-effect.html'} this blog post.
+  %a{href: 'https://www.yegor256.com/2019/05/14/cause-risk-effect.html', title: 'Learn about C+R+E model'} this blog post.

--- a/views/tasks.haml
+++ b/views/tasks.haml
@@ -4,7 +4,7 @@
 - unless wired
   %p
     Talk to our Telegram bot:
-    %a{href: 'https://t.me/zerorsk_bot'}<
+    %a{href: 'https://t.me/zerorsk_bot', title: 'Telegram bot'}<
       %code @zerorsk_bot
 
 %form{method: 'GET', action: ''}
@@ -38,12 +38,12 @@
     %p
       = thumb(t)
       = rank(t)
-      %a{href: iri.over(q: t[:emoji])}<
+      %a{href: iri.over(q: t[:emoji]), title: "Filter by #{t[:emoji]}"}<
         &= t[:emoji]
       %br
       = part('T', t[:id])
       ➜
-      %a{href: iri.cut('/responses').add(id: t[:triple])}<
+      %a{href: iri.cut('/responses'), title: 'View responses'.add(id: t[:triple])}<
         %code= "P#{t[:plan]}"
       ➜
       = part(t[:prefix], t[:part])
@@ -58,25 +58,25 @@
         &= t[:text]
       %br
       %span.small
-        %a.item{href: iri.cut('/projects').append(t[:pid])}<
+        %a.item{href: iri.cut('/projects').append(t[:pid]), title: 'View project'}<
           &= t[:title]
         %span.item<
           &= t[:schedule]
-        %a.item{href: iri.cut('/tasks/done').add(id: t[:id])} Done
+        %a.item{href: iri.cut('/tasks/done').add(id: t[:id]), title: 'Mark as done'} Done
         - unless /^[a-z]+$/.match?(t[:schedule])
           %span.item
             Later:
-            %a{href: iri.cut('/tasks/later').add(id: t[:id], period: 'week')} week
+            %a{href: iri.cut('/tasks/later'), title: 'Postpone'.add(id: t[:id], period: 'week')} week
             = '|'
-            %a{href: iri.cut('/tasks/later').add(id: t[:id], period: 'month')} month
+            %a{href: iri.cut('/tasks/later'), title: 'Postpone'.add(id: t[:id], period: 'month')} month
             = '|'
-            %a{href: iri.cut('/tasks/later').add(id: t[:id], period: 'quarter')} quarter
+            %a{href: iri.cut('/tasks/later'), title: 'Postpone'.add(id: t[:id], period: 'quarter')} quarter
   = Tilt::HamlTemplate.new('views/_paging.haml', 1, format: :xhtml).render(self, locals.merge(count: tasks.count))
 
 %p
   We're checking all your plans regularly and create tasks
   accordingly, when time comes. You can
-  %a{href: iri.cut('/tasks/create')} click here
+  %a{href: iri.cut('/tasks/create'), title: 'Pull latest plans'} click here
   to pull the latest plans in, right now.
   - if updated
     The last time plans were checked

--- a/views/terms.haml
+++ b/views/terms.haml
@@ -34,8 +34,8 @@
 
 %p
   The service and the database are hosted by
-  %a{href: 'https://www.heroku.com'} Heroku.
+  %a{href: 'https://www.heroku.com', title: 'Heroku platform'} Heroku.
 
 %p
   If any questions,
-  %a{href: 'maito:terms@0rsk.com'} email us.
+  %a{href: 'maito:terms@0rsk.com', title: 'Email us'} email us.

--- a/views/triple.haml
+++ b/views/triple.haml
@@ -31,7 +31,7 @@
 
 %p
   Need inspiration? Read this
-  %a{href: 'https://github.com/yegor256/awesome-risks'} curated list.
+  %a{href: 'https://github.com/yegor256/awesome-risks', title: 'Risk examples'} curated list.
 
 %form{method: 'POST', action: iri.cut('/triple/save')}
   %label
@@ -41,11 +41,11 @@
   %input.dimmed#cid{type: 'text', name: 'cid', size: 3, autocomplete: 'off', readonly: true, value: defined?(triple) ? triple[:cid] : '', title: 'The ID of an existing cause'}
   %a#ctext_detach.small.item{href: '#', style: defined?(triple) ? '' : 'display: none;', title: 'Click to detach it from the existing cause'} Detach
   %br
-  %a{href: 'https://unicode.org/emoji/charts/full-emoji-list.html'} Emoji:
+  %a{href: 'https://unicode.org/emoji/charts/full-emoji-list.html', title: 'Emoji reference'} Emoji:
   %input#emoji{type: 'text', name: 'emoji', size: 2, maxlength: 2, autocomplete: 'off', tabindex: 2, placeholder: '💰', value: defined?(triple) ? triple[:emoji] : '💰', required: true}
   - unless emojis.empty?
     - emojis.each do |e|
-      %a{onclick: '$("#emoji").val($(this).text());return false;', href: '#'}= e
+      %a{onclick: '$("#emoji").val($(this).text());return false;', href: '#', title: 'Insert emoji'}= e
   %br
   %label
     Risk:
@@ -91,4 +91,4 @@
 %p
   If you are in doubt and need to learn more about
   the cause+risk+effect model of risk management, read
-  %a{href: 'https://www.yegor256.com/2019/05/14/cause-risk-effect.html'} this blog post.
+  %a{href: 'https://www.yegor256.com/2019/05/14/cause-risk-effect.html', title: 'Learn about C+R+E model'} this blog post.


### PR DESCRIPTION
Fixes #12

Add `title` HTML attribute to all `<a>` links across all Haml views.

## Changes
13 files, 63 links updated with descriptive title attributes:

- Navigation links: "Home", "Your projects", "Login with GitHub", "New risk triple", "Your tasks", "Logout"
- Browse links: "Browse causes/risks/effects/plans", "Ranked risks", "Terms of use"
- External links: "GitHub repository", "Telegram bot", "Zerocracy website", "Heroku platform", "Watch video", "Risk examples", "Emoji reference", "Email us"
- Action links: "Mark as done", "Postpone", "Edit triple", "Delete triple/project", "Detach plan", "Generate new tasks"
- Pagination: "Previous page", "Page N", "Next page"
- Filter links: dynamic "Filter by [emoji]" titles
- Schedule presets: "Daily/Weekly/Biweekly/Monthly/Quarterly/Annual schedule"
- Emoji selector: "Insert emoji"

## Verification
- `Haml::Engine.new(format: :xhtml).call(content)` passes for all 13 modified files
- CI: 43 tests, 116 assertions (awaiting run)
