### PR TITLE
#14: add task counter to favicon and menu

### DIFF
--- a/front/front_misc.rb
+++ b/front/front_misc.rb
@@ -20,6 +20,20 @@ get '/version' do
   Rsk::VERSION
 end
 
+get '/favicon.svg' do
+  content_type 'image/svg+xml'
+  response.headers['Cache-Control'] = 'no-cache'
+  count = @locals[:tasks_count] || 0
+  display = count > 99 ? '99+' : count.to_s
+  color = count.zero? ? '#888' : '#C5283D'
+  sz = count > 9 ? 10 : 14
+  "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'>
+    <circle cx='16' cy='16' r='15' fill='#{color}'/>
+    <text x='16' y='21' text-anchor='middle' fill='white' font-size='#{sz}'
+      font-weight='bold' font-family='Helvetica,Arial,sans-serif'>#{display}</text>
+  </svg>"
+end
+
 not_found do
   status :not_found
   content_type 'text/html', charset: 'utf-8'

--- a/views/layout.haml
+++ b/views/layout.haml
@@ -11,7 +11,7 @@
     %meta{name: 'description', content: 'Online Risk Manager: identify your risks in Cause+Risk+Effect format and let us manage them'}
     %link{href: 'https://cdn.jsdelivr.net/gh/yegor256/tacit@gh-pages/tacit-css.min.css', rel: 'stylesheet'}
     %link{href: 'https://www.yegor256.com/css/icons.css', rel: 'stylesheet'}
-    %link{rel: 'shortcut icon', href: iri.cut('/logo-64.png')}
+    %link{rel: 'shortcut icon', href: '/favicon.svg', type: 'image/svg+xml'}
     %script{src: 'https://code.jquery.com/jquery-3.3.1.min.js'}
     :css
       .item { margin-right: 1em; }
@@ -48,15 +48,13 @@
                 %a{href: iri.cut('/triple')}
                   Add
               %li
-                %a{href: iri.cut('/tasks')}
+                %a{href: iri.cut('/tasks'), title: 'Your tasks'}
+                  Tasks
                   - if tasks_count.zero?
-                    No tasks
-                  - elsif tasks_count == 1
-                    One task
+                    (0)
                   - else
                     %span{class: tasks_count >= Rsk::Tasks::THRESHOLD ? 'red' : ''}
-                      = tasks_count
-                      tasks
+                      = "(#{tasks_count})"
               %li
                 %a{href: iri.cut('/logout')}
                   Logout


### PR DESCRIPTION
Fixes #14

## Changes

### 1. Dynamic favicon with task counter
New route `GET /favicon.svg` generates an SVG favicon showing the current task count:

- Grey circle with "0" when no tasks
- Red circle with task count (up to "99+") when tasks exist
- Uses `@locals[:tasks_count]` already computed by the before filter
- No-cache header ensures count updates on each page load

### 2. Menu format changed to "Tasks (N)"
Simplified the menu to always show "Tasks (N)" format:
- Tasks (0) / Tasks (5) / Tasks (12)
- Red color when count >= threshold (8)
- Cleaner and more compact than the previous "No tasks"/"One task"/"N tasks" variants

## Files
- `front/front_misc.rb`: added `/favicon.svg` route
- `views/layout.haml`: changed favicon link and task menu display

## Verification
- Haml syntax: OK
- Ruby syntax: OK
- CI: awaiting run
