### PR TITLE
#16: add placeholder help lines to all input fields

### DIFF
--- a/views/causes.haml
+++ b/views/causes.haml
@@ -5,7 +5,7 @@
   Causes
 
 %form{method: 'GET', action: ''}
-  %input{type: 'text', name: 'q', size: 40, autocomplete: 'off', autofocus: 'true', tabindex: 1, value: query}
+  %input{type: 'text', name: 'q', size: 40, autocomplete: 'off', autofocus: 'true', tabindex: 1, placeholder: 'Type to search...', value: query}
   %input{type: 'submit', value: 'Search', tabindex: 2}
 
 %p{style: 'font-size: 1.4em;'}

--- a/views/effects.haml
+++ b/views/effects.haml
@@ -5,7 +5,7 @@
   Effects
 
 %form{method: 'GET', action: ''}
-  %input{type: 'text', name: 'q', size: 40, autocomplete: 'off', autofocus: 'true', tabindex: 1, value: query}
+  %input{type: 'text', name: 'q', size: 40, autocomplete: 'off', autofocus: 'true', tabindex: 1, placeholder: 'Type to search...', value: query}
   %input{type: 'submit', value: 'Search', tabindex: 2}
 
 - if effects.empty?

--- a/views/plans.haml
+++ b/views/plans.haml
@@ -5,7 +5,7 @@
   Plans
 
 %form{method: 'GET', action: ''}
-  %input{type: 'text', name: 'q', size: 40, autocomplete: 'off', autofocus: 'true', tabindex: 1, value: query}
+  %input{type: 'text', name: 'q', size: 40, autocomplete: 'off', autofocus: 'true', tabindex: 1, placeholder: 'Type to search...', value: query}
   %input{type: 'submit', value: 'Search', tabindex: 2}
 
 - if plans.empty?

--- a/views/ranked.haml
+++ b/views/ranked.haml
@@ -2,7 +2,7 @@
 -# SPDX-License-Identifier: MIT
 
 %form{method: 'GET', action: ''}
-  %input{type: 'text', name: 'q', size: 40, autocomplete: 'off', autofocus: 'true', tabindex: 1, value: query}
+  %input{type: 'text', name: 'q', size: 40, autocomplete: 'off', autofocus: 'true', tabindex: 1, placeholder: 'Type to search...', value: query}
   %input{type: 'submit', value: 'Search', tabindex: 2}
 
 - unless alone.empty?

--- a/views/responses.haml
+++ b/views/responses.haml
@@ -37,7 +37,7 @@
         %option{value: triple[:rid], selected: true}= "Avoid R#{triple[:rid]}"
         %option{value: triple[:eid]}= "Mitigate E#{triple[:eid]}"
     %label Plan:
-    %input{id: 'plan', type: 'text', name: 'plan', size: 60, maxlength: 160, autocomplete: 'off', tabindex: 2, required: true}
+    %input{id: 'plan', type: 'text', name: 'plan', size: 60, maxlength: 160, autocomplete: 'off', tabindex: 2, placeholder: 'Describe your response strategy', required: true}
     %label<
       %span> Schedule (
       = succeed ',' do
@@ -59,7 +59,7 @@
       = succeed '):' do
         %a{href: '#', id: 'annually'}<
           annually
-    %input{id: 'schedule', type: 'text', name: 'schedule', size: 22, maxlength: 20, autocomplete: 'off', tabindex: 3, required: true}
+    %input{id: 'schedule', type: 'text', name: 'schedule', size: 22, maxlength: 20, autocomplete: 'off', tabindex: 3, placeholder: 'e.g. every month', required: true}
     %label
       %span.item.small Or just once:
       %a.item.small{href: '#', id: 'schedule_asap'} ASAP

--- a/views/risks.haml
+++ b/views/risks.haml
@@ -5,7 +5,7 @@
   Risks
 
 %form{method: 'GET', action: ''}
-  %input{type: 'text', name: 'q', size: 40, autocomplete: 'off', autofocus: 'true', tabindex: 1, value: query}
+  %input{type: 'text', name: 'q', size: 40, autocomplete: 'off', autofocus: 'true', tabindex: 1, placeholder: 'Type to search...', value: query}
   %input{type: 'submit', value: 'Search', tabindex: 2}
 
 - if risks.empty?

--- a/views/tasks.haml
+++ b/views/tasks.haml
@@ -8,7 +8,7 @@
       %code @zerorsk_bot
 
 %form{method: 'GET', action: ''}
-  %input{type: 'text', name: 'q', size: 40, autocomplete: 'off', autofocus: 'true', tabindex: 1, value: query}
+  %input{type: 'text', name: 'q', size: 40, autocomplete: 'off', autofocus: 'true', tabindex: 1, placeholder: 'Type to search...', value: query}
   %input{type: 'submit', value: 'Search', tabindex: 2}
 
 - if tasks.empty?

--- a/views/triple.haml
+++ b/views/triple.haml
@@ -38,13 +38,13 @@
   %label
     Cause:
   %br
-  %input#ctext{type: 'text', name: 'ctext', size: 40, autocomplete: 'off', autofocus: 'true', tabindex: 1, value: defined?(triple) ? triple[:ctext] : '', required: true}
+  %input#ctext{type: 'text', name: 'ctext', size: 40, autocomplete: 'off', autofocus: 'true', tabindex: 1, placeholder: 'Describe the cause of the risk', value: defined?(triple) ? triple[:ctext] : '', required: true}
   %input.dimmed#cid{type: 'text', name: 'cid', size: 3, autocomplete: 'off', readonly: true, value: defined?(triple) ? triple[:cid] : '', title: 'The ID of an existing cause'}
   %a#ctext_detach.small.item{href: '#', style: defined?(triple) ? '' : 'display: none;', title: 'Click to detach it from the existing cause'} Detach
   %br
   = succeed ':' do
     %a{href: 'https://unicode.org/emoji/charts/full-emoji-list.html'} Emoji
-  %input#emoji{type: 'text', name: 'emoji', size: 2, maxlength: 2, autocomplete: 'off', tabindex: 2, value: defined?(triple) ? triple[:emoji] : '💰', required: true}
+  %input#emoji{type: 'text', name: 'emoji', size: 2, maxlength: 2, autocomplete: 'off', tabindex: 2, placeholder: '💰', value: defined?(triple) ? triple[:emoji] : '💰', required: true}
   - unless emojis.empty?
     - emojis.each do |e|
       %a{onclick: '$("#emoji").val($(this).text());return false;', href: '#'}= e
@@ -52,7 +52,7 @@
   %label
     Risk:
   %br
-  %input#rtext{type: 'text', name: 'rtext', size: 50, maxlength: 160, tabindex: 3, value: defined?(triple) ? triple[:rtext] : '', required: true}
+  %input#rtext{type: 'text', name: 'rtext', size: 50, maxlength: 160, tabindex: 3, placeholder: 'Describe the risk itself', value: defined?(triple) ? triple[:rtext] : '', required: true}
   %input.dimmed#rid{type: 'text', name: 'rid', size: 3, autocomplete: 'off', readonly: true, value: defined?(triple) ? triple[:rid] : '', title: 'The ID of an existing risk'}
   %a#rtext_detach.small.item{href: '#', style: defined?(triple) ? '' : 'display: none;', title: 'Click to detach it from the existing risk'} Detach
   %br
@@ -66,7 +66,7 @@
   %label
     Effect:
   %br
-  %input#etext{type: 'text', name: 'etext', size: 60, maxlength: 160, autocomplete: 'off', tabindex: 5, value: defined?(triple) ? triple[:etext] : '', required: true}
+  %input#etext{type: 'text', name: 'etext', size: 60, maxlength: 160, autocomplete: 'off', tabindex: 5, placeholder: 'Describe the potential impact', value: defined?(triple) ? triple[:etext] : '', required: true}
   %input.dimmed#eid{type: 'text', name: 'eid', size: 3, autocomplete: 'off', readonly: true, value: defined?(triple) ? triple[:eid] : '', title: 'The ID of an existing effect'}
   %a#etext_detach.small.item{href: '#', style: defined?(triple) ? '' : 'display: none;', title: 'Click to detach it from the existing effect'} Detach
   %br


### PR DESCRIPTION
Fixes #16

Add `placeholder` help lines to all text input fields across the application to explain what they mean and how to use them.

## Changes
8 files, 12 placeholders added:

- **Search fields** (6 pages): `placeholder: 'Type to search...'` on causes, effects, plans, ranked, risks, tasks
- **Triple editor** (4 fields):
  - Cause: `placeholder: 'Describe the cause of the risk'`
  - Emoji: `placeholder: '💰'` (shows the expected format)
  - Risk: `placeholder: 'Describe the risk itself'`
  - Effect: `placeholder: 'Describe the potential impact'`
- **Response plan form** (2 fields):
  - Plan: `placeholder: 'Describe your response strategy'`
  - Schedule: `placeholder: 'e.g. every month'`

## Verification
- All 16 Haml files pass syntax check
- CI: awaiting run
