### PR TITLE
# 21: Part A add tracker table, model, and UI for GitHub integration

### DIFF
--- a/0rsk.rb
+++ b/0rsk.rb
@@ -131,7 +131,7 @@ end
 
 post '/project/{id}/tracker/delete' do
   pid = params[:id]
-  tid = params[:tid].to_i
+  tid = Integer(params[:tid], 10)
   raise Rsk::Urror, "Project ##{pid} not found" unless projects.exists?(pid)
   trackers(pid: pid).delete(tid)
   flash("/project/#{pid}", 'Tracker removed')

--- a/0rsk.rb
+++ b/0rsk.rb
@@ -119,7 +119,22 @@ end
 get '/project/{id}' do
   pid = params[:id]
   raise Rsk::Urror, "Project ##{pid} not found" unless projects.exists?(pid)
-  haml :project, layout: :layout, locals: merged(title: "##{pid}", pid: pid)
+  haml :project, layout: :layout, locals: merged(title: "##{pid}", pid: pid, trackers: trackers(pid: pid).fetch)
+end
+
+post '/project/{id}/tracker/add' do
+  pid = params[:id]
+  raise Rsk::Urror, "Project ##{pid} not found" unless projects.exists?(pid)
+  trackers(pid: pid).add(params[:repo], params[:token])
+  flash("/project/#{pid}", 'Tracker added')
+end
+
+post '/project/{id}/tracker/delete' do
+  pid = params[:id]
+  tid = params[:tid].to_i
+  raise Rsk::Urror, "Project ##{pid} not found" unless projects.exists?(pid)
+  trackers(pid: pid).delete(tid)
+  flash("/project/#{pid}", 'Tracker removed')
 end
 
 get '/responses' do
@@ -259,6 +274,11 @@ module Rsk::App
   def plans(project: pid)
     require_relative('objects/plans')
     Rsk::Plans.new(settings.pgsql, project)
+  end
+
+  def trackers(pid:)
+    require_relative('objects/trackers')
+    Rsk::Trackers.new(settings.pgsql, pid)
   end
 
   def iri

--- a/liquibase/2019/014-tracker.xml
+++ b/liquibase/2019/014-tracker.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd" logicalFilePath="001-initial-schema.xml">
+  <changeSet id="014" author="yegor256">
+    <sql>
+      CREATE TABLE tracker (
+        id SERIAL PRIMARY KEY,
+        project INT NOT NULL REFERENCES project(id),
+        type VARCHAR(32) NOT NULL DEFAULT 'github',
+        repo VARCHAR(256) NOT NULL,
+        token VARCHAR(256) NOT NULL,
+        created TIMESTAMPTZ DEFAULT now() NOT NULL
+      );
+      CREATE INDEX idx_tracker1 ON tracker(project);
+    </sql>
+  </changeSet>
+</databaseChangeLog>

--- a/objects/trackers.rb
+++ b/objects/trackers.rb
@@ -12,16 +12,18 @@ class Rsk::Trackers
   end
 
   def add(repo, token)
-    @pgsql.exec(
-      'INSERT INTO tracker (project, repo, token) VALUES ($1, $2, $3) RETURNING id',
-      [@project, repo, token]
-    )[0]['id'].to_i
+    Integer(
+      @pgsql.exec(
+        'INSERT INTO tracker (project, repo, token) VALUES ($1, $2, $3) RETURNING id',
+        [@project, repo, token]
+      )[0]['id'], 10
+    )
   end
 
   def fetch
     @pgsql.exec('SELECT * FROM tracker WHERE project = $1 ORDER BY created', [@project]).map do |r|
       {
-        id: r['id'].to_i,
+        id: Integer(r['id'], 10),
         type: r['type'],
         repo: r['repo'],
         created: Time.parse(r['created'])

--- a/objects/trackers.rb
+++ b/objects/trackers.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'rsk'
+
+class Rsk::Trackers
+  def initialize(pgsql, project)
+    @pgsql = pgsql
+    @project = project
+  end
+
+  def add(repo, token)
+    @pgsql.exec(
+      'INSERT INTO tracker (project, repo, token) VALUES ($1, $2, $3) RETURNING id',
+      [@project, repo, token]
+    )[0]['id'].to_i
+  end
+
+  def fetch
+    @pgsql.exec('SELECT * FROM tracker WHERE project = $1 ORDER BY created', [@project]).map do |r|
+      {
+        id: r['id'].to_i,
+        type: r['type'],
+        repo: r['repo'],
+        created: Time.parse(r['created'])
+      }
+    end
+  end
+
+  def exists?(id)
+    !@pgsql.exec('SELECT id FROM tracker WHERE id = $1 AND project = $2', [id, @project]).empty?
+  end
+
+  def delete(id)
+    @pgsql.exec('DELETE FROM tracker WHERE id = $1 AND project = $2', [id, @project])
+  end
+end

--- a/views/project.haml
+++ b/views/project.haml
@@ -11,3 +11,44 @@
 %p
   See
   %a{href: iri.cut('/projects')} all projects
+
+%h3 Trackers
+
+- if trackers.empty?
+  %p No trackers configured yet.
+- else
+  %p The following trackers are connected:
+  %table
+    %tr
+      %th Type
+      %th Repo
+      %th Created
+      %th
+    - trackers.each do |t|
+      %tr
+        %td= t[:type]
+        %td= t[:repo]
+        %td= t[:created].strftime('%Y-%m-%d')
+        %td
+          %form{method: 'POST', action: "/project/#{pid}/tracker/delete"}
+            %input{type: 'hidden', name: 'tid', value: t[:id]}
+            %input{type: 'submit', value: 'Delete'}
+
+%form{method: 'POST', action: "/project/#{pid}/tracker/add"}
+  %fieldset
+    %legend Add a new tracker
+    %p
+      %label
+        Type:
+        %select{name: 'type'}
+          %option{value: 'github'} GitHub
+    %p
+      %label
+        Repository (owner/name):
+        %input{type: 'text', name: 'repo', size: 40, placeholder: 'e.g. myorg/myproject'}
+    %p
+      %label
+        Access token:
+        %input{type: 'password', name: 'token', size: 40}
+    %p
+      %input{type: 'submit', value: 'Add Tracker'}


### PR DESCRIPTION
Part A of #21

Add database schema, model, and UI for connecting project tasks with external trackers (starting with GitHub).

## Changes

### New: `liquibase/2019/014-tracker.xml`
Creates `tracker` table:
- `id` SERIAL PRIMARY KEY
- `project` FK → project(id)
- `type` VARCHAR (default 'github')
- `repo` VARCHAR(256) — repository owner/name
- `token` VARCHAR(256) — GitHub access token
- `created` TIMESTAMPTZ

### New: `objects/trackers.rb`
`Rsk::Trackers` model (collection):
- `add(repo, token)` — configure a new tracker for a project
- `fetch` — list all trackers for a project
- `delete(id)` — remove a tracker
- `exists?(id)` — check ownership

### Modified: `0rsk.rb`
- Added `GET /project/{id}` now includes `trackers` list in locals
- Added `POST /project/{id}/tracker/add` — create a tracker
- Added `POST /project/{id}/tracker/delete` — remove a tracker
- Added `trackers(pid:)` helper method (lazy require pattern)

### Modified: `views/project.haml`
- Added "Trackers" section showing configured trackers with Delete button
- Added "Add a new tracker" form (repo + token fields)

## Next Steps (future PRs)
- **Part B**: Octokit gem + daemon to create GitHub issues from tasks
- **Part C**: Webhook endpoint to close tasks when GitHub issues are closed

## Verification
- Ruby syntax: OK
- Haml syntax: OK
- CI: awaiting run
