### PR TITLE
#32: Low test coverage — add tests for Rsk::Project and Rsk::Plan

### DIFF
--- a/test/test_plan.rb
+++ b/test/test_plan.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'test__helper'
+require_relative '../objects/rsk'
+require_relative '../objects/projects'
+require_relative '../objects/risks'
+require_relative '../objects/plans'
+require_relative '../objects/urror'
+
+class Rsk::PlanTest < Minitest::Test
+  def test_reads_schedule
+    plan = make_plan
+    assert_kind_of(String, plan.schedule)
+  end
+
+  def test_modifies_schedule
+    plan = make_plan
+    plan.schedule = 'weekly'
+    assert_equal('weekly', plan.schedule)
+    plan.schedule = '01-01-2030'
+    assert_equal('01-01-2030', plan.schedule)
+  end
+
+  def test_rejects_invalid_schedule
+    plan = make_plan
+    assert_raises(Rsk::Urror) { plan.schedule = 'bad' }
+  end
+
+  def test_completes_word_schedule
+    plan = make_plan
+    plan.schedule = 'daily'
+    plan.complete
+    assert_kind_of(String, plan.schedule)
+  end
+
+  def test_completes_date_schedule_detaches
+    pid = Rsk::Projects.new(test_pgsql, "planX#{rand(99_999)}").add("px#{rand(99_999)}")
+    rid = Rsk::Risks.new(test_pgsql, pid).add('we may lose')
+    plans = Rsk::Plans.new(test_pgsql, pid)
+    id = plans.add(rid, 'backup')
+    plan = plans.get(id, rid)
+    orig_count = plans.count
+    plan.schedule = '01-01-2001'
+    plan.complete
+    assert_equal(orig_count - 1, plans.count)
+  end
+
+  private
+
+  def make_plan
+    pid = Rsk::Projects.new(test_pgsql, "planT#{rand(99_999)}").add("pt#{rand(99_999)}")
+    rid = Rsk::Risks.new(test_pgsql, pid).add('we may lose data')
+    plans = Rsk::Plans.new(test_pgsql, pid)
+    id = plans.add(rid, 'we make backups')
+    plans.get(id, rid)
+  end
+end

--- a/test/test_plan.rb
+++ b/test/test_plan.rb
@@ -4,57 +4,51 @@
 # SPDX-License-Identifier: MIT
 
 require_relative 'test__helper'
-require_relative '../objects/rsk'
+
+require_relative '../objects/plans'
 require_relative '../objects/projects'
 require_relative '../objects/risks'
-require_relative '../objects/plans'
+require_relative '../objects/rsk'
 require_relative '../objects/urror'
 
-class Rsk::PlanTest < Minitest::Test
+class Rsk::PlanTest < TestCase
   def test_reads_schedule
-    plan = make_plan
-    assert_kind_of(String, plan.schedule)
+    assert_equal('weekly', with_plan.schedule)
   end
 
   def test_modifies_schedule
-    plan = make_plan
-    plan.schedule = 'weekly'
+    plan = with_plan
+    plan.reschedule('weekly')
     assert_equal('weekly', plan.schedule)
-    plan.schedule = '01-01-2030'
+    plan.reschedule('01-01-2030')
     assert_equal('01-01-2030', plan.schedule)
   end
 
   def test_rejects_invalid_schedule
-    plan = make_plan
-    assert_raises(Rsk::Urror) { plan.schedule = 'bad' }
+    plan = with_plan
+    assert_raises(Rsk::Urror) { plan.reschedule('bad') }
   end
 
   def test_completes_word_schedule
-    plan = make_plan
-    plan.schedule = 'daily'
+    plan = with_plan(login: "planW#{SecureRandom.hex(8)}", title: "pw#{SecureRandom.hex(8)}")
+    plan.reschedule('daily')
     plan.complete
-    assert_kind_of(String, plan.schedule)
+    assert_equal(1, @plans.count)
   end
 
   def test_completes_date_schedule_detaches
-    pid = Rsk::Projects.new(test_pgsql, "planX#{rand(99_999)}").add("px#{rand(99_999)}")
-    rid = Rsk::Risks.new(test_pgsql, pid).add('we may lose')
-    plans = Rsk::Plans.new(test_pgsql, pid)
-    id = plans.add(rid, 'backup')
-    plan = plans.get(id, rid)
-    orig_count = plans.count
-    plan.schedule = '01-01-2001'
+    plan = with_plan(login: "planX#{SecureRandom.hex(8)}", title: "px#{SecureRandom.hex(8)}")
+    plan.reschedule('01-01-2001')
     plan.complete
-    assert_equal(orig_count - 1, plans.count)
+    assert_equal(0, @plans.count)
   end
 
   private
 
-  def make_plan
-    pid = Rsk::Projects.new(test_pgsql, "planT#{rand(99_999)}").add("pt#{rand(99_999)}")
+  def with_plan(login: "planT#{SecureRandom.hex(8)}", title: "pt#{SecureRandom.hex(8)}")
+    pid = Rsk::Projects.new(test_pgsql, login).add(title)
     rid = Rsk::Risks.new(test_pgsql, pid).add('we may lose data')
-    plans = Rsk::Plans.new(test_pgsql, pid)
-    id = plans.add(rid, 'we make backups')
-    plans.get(id, rid)
+    @plans = Rsk::Plans.new(test_pgsql, pid)
+    @plans.get(@plans.add(rid, 'we make backups'), rid)
   end
 end

--- a/test/test_project.rb
+++ b/test/test_project.rb
@@ -4,14 +4,20 @@
 # SPDX-License-Identifier: MIT
 
 require_relative 'test__helper'
-require_relative '../objects/rsk'
-require_relative '../objects/projects'
-require_relative '../objects/project'
 
-class Rsk::ProjectTest < Minitest::Test
+require_relative '../objects/project'
+require_relative '../objects/projects'
+require_relative '../objects/rsk'
+
+class Rsk::ProjectTest < TestCase
   def test_fetches_login
-    login = "plin#{rand(99_999)}"
-    pid = Rsk::Projects.new(test_pgsql, login).add("t#{rand(99_999)}")
-    assert_equal(login, Rsk::Project.new(test_pgsql, pid).login)
+    login = "plin#{SecureRandom.hex(8)}"
+    assert_equal(
+      login,
+      Rsk::Project.new(
+        test_pgsql,
+        Rsk::Projects.new(test_pgsql, login).add("t#{SecureRandom.hex(8)}")
+      ).login
+    )
   end
 end

--- a/test/test_project.rb
+++ b/test/test_project.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'test__helper'
+require_relative '../objects/rsk'
+require_relative '../objects/projects'
+require_relative '../objects/project'
+
+class Rsk::ProjectTest < Minitest::Test
+  def test_fetches_login
+    login = "plin#{rand(99_999)}"
+    pid = Rsk::Projects.new(test_pgsql, login).add("t#{rand(99_999)}")
+    assert_equal(login, Rsk::Project.new(test_pgsql, pid).login)
+  end
+end


### PR DESCRIPTION
Closes #32

Added tests for two previously-untested singleton models:

- **test/test_project.rb** — `Rsk::Project#login`
- **test/test_plan.rb** — `Rsk::Plan#schedule` (read/write/validation), `#complete` (word schedule), `#complete` (date schedule → detach)

5 new tests total. RuboCop: 0 offenses.