### PR TITLE
#147: Make eslint optional when no JS runtime is available

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -26,10 +26,15 @@ RuboCop::RakeTask.new(:rubocop) do |task|
   task.fail_on_error = true
 end
 
-require 'eslintrb/eslinttask'
-Eslintrb::EslintTask.new(:eslint) do |t|
-  t.pattern = 'js/**/*.js'
-  t.options = :defaults
+begin
+  require 'eslintrb/eslinttask'
+  Eslintrb::EslintTask.new(:eslint) do |t|
+    t.pattern = 'js/**/*.js'
+    t.options = :defaults
+  end
+rescue ExecJS::RuntimeUnavailable, LoadError => e
+  desc 'eslint (disabled — no JS runtime)'
+  task(:eslint) { warn "eslint disabled: #{e.message}" }
 end
 
 require 'pgtk/pgsql_task'


### PR DESCRIPTION
Fixes #147

Wraps `eslintrb` require and task definition in a `begin/rescue ExecJS::RuntimeUnavailable, LoadError`. When no JavaScript runtime is installed (e.g., Node.js missing), eslint gracefully degrades with a warning instead of crashing `bundle exec rake`.

The `rake test` task was already unaffected since it doesn't include eslint as a prerequisite.
