### PR TITLE
#154: Add config.ru for rackup to fix broken rake run task

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require './0rsk'
+run Sinatra::Application


### PR DESCRIPTION
Fixes #154

Adds `config.ru` (standard Rack configuration file) so `rackup` can start the Sinatra application properly. The existing `bundle exec rake run` command now works.