### PR TITLE
#156: Handle duplicate project title gracefully

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -63,20 +63,17 @@ end
 
 desc 'Load sample data for development/demo'
 task(seed_dummy: %i[pgsql liquibase]) do
-  require 'yaml'
   require 'loog'
   require 'pgtk/pool'
-  require_relative 'objects/rsk'
-  require_relative 'objects/projects'
+  require 'yaml'
   require_relative 'objects/causes'
-  require_relative 'objects/risks'
   require_relative 'objects/effects'
-  require_relative 'objects/triples'
   require_relative 'objects/plans'
-  pgsql = Pgtk::Pool.new(
-    Pgtk::Wire::Yaml.new('target/pgsql-config.yml'),
-    log: Loog::NULL
-  ).start
+  require_relative 'objects/projects'
+  require_relative 'objects/risks'
+  require_relative 'objects/rsk'
+  require_relative 'objects/triples'
+  pgsql = Pgtk::Pool.new(Pgtk::Wire::Yaml.new('target/pgsql-config.yml'), log: Loog::NULL).start
   fixtures = YAML.safe_load(File.read('liquibase/fixtures.yml'))
   fixtures.each do |key, data|
     login = "demo_#{key}"

--- a/objects/projects.rb
+++ b/objects/projects.rb
@@ -17,6 +17,8 @@ class Rsk::Projects
       @pgsql.exec('INSERT INTO project (login, title) VALUES ($1, $2) RETURNING id', [@login, title])[0]['id'],
       10
     )
+  rescue PG::UniqueViolation
+    raise(Rsk::Urror, "Project with title \"#{title}\" already exists")
   end
 
   def delete(id)


### PR DESCRIPTION
Fixes #156

Catches `PG::UniqueViolation` in `Rsk::Projects#add` and raises `Rsk::Urror` with a user-friendly message instead of crashing with a raw PG exception.

The existing `error` handler in `front_misc.rb` already catches `Rsk::Urror` and shows it as a flash message.