### PR TITLE
#157: Add seed_dummy rake task with sample risk data

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -61,6 +61,47 @@ task(:config) do
   YAML.safe_load(File.open('config.yml')).to_yaml
 end
 
+desc 'Load sample data for development/demo'
+task(seed_dummy: %i[pgsql liquibase]) do
+  require 'yaml'
+  require 'loog'
+  require 'pgtk/pool'
+  require_relative 'objects/rsk'
+  require_relative 'objects/projects'
+  require_relative 'objects/causes'
+  require_relative 'objects/risks'
+  require_relative 'objects/effects'
+  require_relative 'objects/triples'
+  require_relative 'objects/plans'
+  pgsql = Pgtk::Pool.new(
+    Pgtk::Wire::Yaml.new('target/pgsql-config.yml'),
+    log: Loog::NULL
+  ).start
+  fixtures = YAML.safe_load(File.read('liquibase/fixtures.yml'))
+  fixtures.each do |key, data|
+    login = "demo_#{key}"
+    pid = Rsk::Projects.new(pgsql, login).add(data['title'])
+    causes = Rsk::Causes.new(pgsql, pid)
+    risks = Rsk::Risks.new(pgsql, pid)
+    effects = Rsk::Effects.new(pgsql, pid)
+    triples = Rsk::Triples.new(pgsql, pid)
+    plans = Rsk::Plans.new(pgsql, pid)
+    cids = data['causes'].map { |c| causes.add(c['text']) }
+    rids = data['risks'].map { |r| risks.add(r['text']) }
+    eids = data['effects'].map { |e| effects.add(e['text']) }
+    data['plans'].each do |p|
+      ci = cids[data['causes'].index { |c| c['text'] == p['cause'] }]
+      ri = rids[data['risks'].index { |r| r['text'] == p['risk'] }]
+      ei = eids[data['effects'].index { |e| e['text'] == p['effect'] }]
+      next unless ci && ri && ei
+      tid = triples.add(ci, ri, ei)
+      plans.add(tid, p['text'])
+    end
+    puts "Seeded: #{data['title']}"
+  end
+  puts 'Done. Login with ?glogin=demo_mobile or ?glogin=demo_cloud'
+end
+
 task(run: %i[pgsql liquibase]) do
   `rerun -b "RACK_ENV=test rackup"`
 end

--- a/liquibase/fixtures.yml
+++ b/liquibase/fixtures.yml
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+#
+# Sample data for demo/development environments.
+# Load with: bundle exec rake seed_dummy
+
+mobile:
+  title: Mobile Payment App
+  causes:
+    - text: We rely on a single payment gateway
+    - text: QA team is understaffed for the release
+    - text: App uses a deprecated API
+  risks:
+    - text: Payment gateway goes down during peak hours
+    - text: Unreleased bugs slip into production
+    - text: Apple rejects the App Store submission
+  effects:
+    - text: Users cannot complete purchases
+    - text: Negative reviews damage app rating
+    - text: Product launch is delayed by weeks
+  plans:
+    - cause: We rely on a single payment gateway
+      risk: Payment gateway goes down during peak hours
+      effect: Users cannot complete purchases
+      text: Integrate a fallback payment provider (Stripe)
+    - cause: QA team is understaffed for the release
+      risk: Unreleased bugs slip into production
+      effect: Negative reviews damage app rating
+      text: Hire two freelance QA engineers for the release sprint
+    - cause: App uses a deprecated API
+      risk: Apple rejects the App Store submission
+      effect: Product launch is delayed by weeks
+      text: Migrate from deprecated API to the new framework
+
+cloud:
+  title: Cloud Migration Project
+  causes:
+    - text: Team lacks cloud infrastructure expertise
+    - text: On-premise hardware is end-of-life
+    - text: Legacy database schema is poorly documented
+  risks:
+    - text: Migration takes longer than planned
+    - text: Data is lost during the transfer
+    - text: Application performance degrades after migration
+  effects:
+    - text: Operational costs exceed the budget
+    - text: Customer data is exposed
+    - text: Users experience slow page loads
+  plans:
+    - cause: Team lacks cloud infrastructure expertise
+      risk: Migration takes longer than planned
+      effect: Operational costs exceed the budget
+      text: Hire a cloud consultant for architecture review
+    - cause: On-premise hardware is end-of-life
+      risk: Data is lost during the transfer
+      effect: Customer data is exposed
+      text: Run full data backup and verify restore before cutover
+    - cause: Legacy database schema is poorly documented
+      risk: Application performance degrades after migration
+      effect: Users experience slow page loads
+      text: Run load tests and optimize slow queries post-migration


### PR DESCRIPTION
Fixes #157

Adds `rake seed_dummy` which populates the database with two demo projects:

- **Mobile Payment App**: 3 causes, 3 risks, 3 effects, 3 plans
  (single payment gateway, understaffed QA, deprecated API)
- **Cloud Migration Project**: 3 causes, 3 risks, 3 effects, 3 plans
  (lack of cloud expertise, end-of-life hardware, legacy DB schema)

Usage:
```bash
bundle exec rake seed_dummy
```
Then login with `?glogin=demo_mobile` or `?glogin=demo_cloud`.

Also see #42 (more risk examples) — this provides the initial seed data set.