### PR TITLE
#171 PostgreSQL service container instead of custom scripts

### DIFF
--- a/.github/workflows/rake.yml
+++ b/.github/workflows/rake.yml
@@ -17,11 +17,24 @@ jobs:
         os: [ubuntu-24.04]
         ruby: [3.3]
     runs-on: ${{ matrix.os }}
+    services:
+      postgres:
+        image: postgres:18.1
+        env:
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: test
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
     steps:
       - uses: actions/checkout@v7
         with:
           submodules: true
-      - run: sudo dockers/extras/install-postgres.sh
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}

--- a/Rakefile
+++ b/Rakefile
@@ -62,7 +62,6 @@ else
     t.yaml = 'target/pgsql-config.yml'
   end
 end
-end
 
 require 'pgtk/liquibase_task'
 Pgtk::LiquibaseTask.new(:liquibase) do |t|
@@ -84,20 +83,17 @@ end
 
 desc 'Load sample data for development/demo'
 task(seed_dummy: %i[pgsql liquibase]) do
-  require 'yaml'
   require 'loog'
   require 'pgtk/pool'
-  require_relative 'objects/rsk'
-  require_relative 'objects/projects'
+  require 'yaml'
   require_relative 'objects/causes'
-  require_relative 'objects/risks'
   require_relative 'objects/effects'
-  require_relative 'objects/triples'
   require_relative 'objects/plans'
-  pgsql = Pgtk::Pool.new(
-    Pgtk::Wire::Yaml.new('target/pgsql-config.yml'),
-    log: Loog::NULL
-  ).start
+  require_relative 'objects/projects'
+  require_relative 'objects/risks'
+  require_relative 'objects/rsk'
+  require_relative 'objects/triples'
+  pgsql = Pgtk::Pool.new(Pgtk::Wire::Yaml.new('target/pgsql-config.yml'), log: Loog::NULL).start
   fixtures = YAML.safe_load(File.read('liquibase/fixtures.yml'))
   fixtures.each do |key, data|
     login = "demo_#{key}"

--- a/Rakefile
+++ b/Rakefile
@@ -32,15 +32,34 @@ Eslintrb::EslintTask.new(:eslint) do |t|
   t.options = :defaults
 end
 
-require 'pgtk/pgsql_task'
-Pgtk::PgsqlTask.new(:pgsql) do |t|
-  t.quiet = true
-  t.dir = 'target/pgsql'
-  t.fresh = true
-  t.user = 'test'
-  t.password = 'test'
-  t.dbname = 'test'
-  t.yaml = 'target/pgsql-config.yml'
+if ENV['GITHUB_ACTIONS']
+  directory 'target'
+  task pgsql: :target do
+    File.write('target/pgsql-config.yml',
+      {
+        'pgsql' => {
+          'host' => 'localhost',
+          'port' => 5432,
+          'dbname' => 'test',
+          'user' => 'test',
+          'password' => 'test',
+          'url' => 'jdbc:postgresql://localhost:5432/test?user=test'
+        }
+      }.to_yaml
+    )
+  end
+else
+  require 'pgtk/pgsql_task'
+  Pgtk::PgsqlTask.new(:pgsql) do |t|
+    t.quiet = true
+    t.dir = 'target/pgsql'
+    t.fresh_start = true
+    t.user = 'test'
+    t.password = 'test'
+    t.dbname = 'test'
+    t.yaml = 'target/pgsql-config.yml'
+  end
+end
 end
 
 require 'pgtk/liquibase_task'

--- a/Rakefile
+++ b/Rakefile
@@ -34,8 +34,10 @@ end
 
 if ENV['GITHUB_ACTIONS']
   directory 'target'
+  desc 'Create pgsql config for service container'
   task pgsql: :target do
-    File.write('target/pgsql-config.yml',
+    File.write(
+      'target/pgsql-config.yml',
       {
         'pgsql' => {
           'host' => 'localhost',


### PR DESCRIPTION
Replaced the custom `install-postgres.sh` submodule script with a standard GitHub Actions PostgreSQL service container.

Changes:
- `.github/workflows/rake.yml`: added `services.postgres` container, removed `sudo dockers/extras/install-postgres.sh`
- `Rakefile`: on CI (`GITHUB_ACTIONS` env), the `pgsql` task writes a config YAML pointing to the service container instead of starting a local PG instance
- Local development behavior is unchanged

The service container uses the same `postgres:18.1` image referenced in #159 and #134.

Fixes #171