### PR TITLE
#175: remove test env guard from Sentry.init

### DIFF
--- a/0rsk.rb
+++ b/0rsk.rb
@@ -38,11 +38,9 @@ configure do
     'sentry' => ''
   }
   config = YAML.safe_load(File.open(File.join(File.dirname(__FILE__), 'config.yml'))) unless ENV['RACK_ENV'] == 'test'
-  if ENV['RACK_ENV'] != 'test'
-    Sentry.init do |c|
-      c.dsn = config['sentry']
-      c.release = Rsk::VERSION
-    end
+  Sentry.init do |c|
+    c.dsn = config['sentry']
+    c.release = Rsk::VERSION
   end
   set :bind, '0.0.0.0'
   set :server, :thin


### PR DESCRIPTION
The `if ENV['RACK_ENV'] != 'test'` guard around `Sentry.init` creates environment-specific behavior that can hide bugs — if Sentry config code fails in test, tests still pass.

Sentry disables itself when DSN is empty (as it is in test by default), so the guard is unnecessary.

Removed the guard. Sentry is now configured uniformly across all environments.

Fixes #175