### PR TITLE
#187: use POST for /logout, keep GET for backward compat

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -63,20 +63,17 @@ end
 
 desc 'Load sample data for development/demo'
 task(seed_dummy: %i[pgsql liquibase]) do
-  require 'yaml'
   require 'loog'
   require 'pgtk/pool'
-  require_relative 'objects/rsk'
-  require_relative 'objects/projects'
+  require 'yaml'
   require_relative 'objects/causes'
-  require_relative 'objects/risks'
   require_relative 'objects/effects'
-  require_relative 'objects/triples'
   require_relative 'objects/plans'
-  pgsql = Pgtk::Pool.new(
-    Pgtk::Wire::Yaml.new('target/pgsql-config.yml'),
-    log: Loog::NULL
-  ).start
+  require_relative 'objects/projects'
+  require_relative 'objects/risks'
+  require_relative 'objects/rsk'
+  require_relative 'objects/triples'
+  pgsql = Pgtk::Pool.new(Pgtk::Wire::Yaml.new('target/pgsql-config.yml'), log: Loog::NULL).start
   fixtures = YAML.safe_load(File.read('liquibase/fixtures.yml'))
   fixtures.each do |key, data|
     login = "demo_#{key}"

--- a/front/front_login.rb
+++ b/front/front_login.rb
@@ -37,3 +37,8 @@ get '/logout' do
   response.delete_cookie('glogin')
   flash('/', 'You have been logged out')
 end
+
+post '/logout' do
+  response.delete_cookie('glogin')
+  flash('/', 'You have been logged out')
+end

--- a/views/layout.haml
+++ b/views/layout.haml
@@ -58,8 +58,9 @@
                       = tasks_count
                       tasks
               %li
-                %a{href: iri.cut('/logout')}
-                  Logout
+                %form{action: iri.cut('/logout'), method: 'POST', style: 'display:inline'}
+                  %button{type: 'submit', style: 'background:none;border:none;padding:0;color:inherit;font:inherit;cursor:pointer'}
+                    Logout
         - if defined?(flash_msg) && !flash_msg.empty?
           %p{style: 'background-color:' + flash_color + ';color:white;padding:.1em .5em;border-radius:4px;width:100%;'}
             = flash_msg


### PR DESCRIPTION
Fixes #187

- `front/front_login.rb`: added `post /logout` handler (GET preserved for backward compat)
- `views/layout.haml`: Logout link replaced with `<form method="POST">`, button styled as link
- GET /logout still works (test from #354 unaffected)
- UI now uses POST