### PR TITLE
#189: add test for GET /projects/delete

### DIFF
--- a/test/test_0rsk.rb
+++ b/test/test_0rsk.rb
@@ -116,6 +116,15 @@ class Rsk::AppTest < Minitest::Test
     assert_includes(cookie.to_s, 'deleted')
   end
 
+  def test_deletes_project
+    get("/projects/delete?id=#{login("deleter#{rand(99_999)}")}")
+    assert_equal(302, last_response.status, last_response.body)
+    assert(last_response.location.end_with?('/projects'))
+    cookie = last_response.headers['Set-Cookie']
+    refute_nil(cookie, last_response.body)
+    assert_includes(cookie.to_s, 'deleted')
+  end
+
   private
 
   def login(name)


### PR DESCRIPTION
Fixes #189

- Modified `login` helper to return the created project ID
- Added `test_deletes_project` — creates project, deletes via GET, verifies 302 + success message in redirect