### PR TITLE
#190: use POST for /projects/delete, keep GET for backward compat

### DIFF
--- a/0rsk.rb
+++ b/0rsk.rb
@@ -105,6 +105,12 @@ get '/projects/delete' do
   flash('/projects', "The project ##{pid} has been deleted")
 end
 
+post '/projects/delete' do
+  pid = params[:id]
+  projects.delete(pid)
+  flash('/projects', "The project ##{pid} has been deleted")
+end
+
 get '/project/{id}' do
   pid = params[:id]
   raise Rsk::Urror, "Project ##{pid} not found" unless projects.exists?(pid)

--- a/Rakefile
+++ b/Rakefile
@@ -63,20 +63,17 @@ end
 
 desc 'Load sample data for development/demo'
 task(seed_dummy: %i[pgsql liquibase]) do
-  require 'yaml'
   require 'loog'
   require 'pgtk/pool'
-  require_relative 'objects/rsk'
-  require_relative 'objects/projects'
+  require 'yaml'
   require_relative 'objects/causes'
-  require_relative 'objects/risks'
   require_relative 'objects/effects'
-  require_relative 'objects/triples'
   require_relative 'objects/plans'
-  pgsql = Pgtk::Pool.new(
-    Pgtk::Wire::Yaml.new('target/pgsql-config.yml'),
-    log: Loog::NULL
-  ).start
+  require_relative 'objects/projects'
+  require_relative 'objects/risks'
+  require_relative 'objects/rsk'
+  require_relative 'objects/triples'
+  pgsql = Pgtk::Pool.new(Pgtk::Wire::Yaml.new('target/pgsql-config.yml'), log: Loog::NULL).start
   fixtures = YAML.safe_load(File.read('liquibase/fixtures.yml'))
   fixtures.each do |key, data|
     login = "demo_#{key}"

--- a/views/projects.haml
+++ b/views/projects.haml
@@ -23,4 +23,6 @@
         &= p[:title]
       %br
       %span.small
-        %a.item{href: iri.cut('/projects/delete').add(id: p[:id]), onclick: "return confirm('Are sure you want to delete it?');"} Delete
+        %form{action: iri.cut('/projects/delete').add(id: p[:id]), method: 'POST', style: 'display:inline', onsubmit: "return confirm('Are sure you want to delete it?')"}
+  %button{type: 'submit', style: 'background:none;border:none;padding:0;color:inherit;font:inherit;cursor:pointer'}
+    Delete


### PR DESCRIPTION
Fixes #190

- `0rsk.rb`: added `post /projects/delete` handler (GET preserved for backward compat)
- `views/projects.haml`: Delete link replaced with `<form method="POST">`, button styled as link
- `onsubmit` confirm dialog preserved
- GET /projects/delete still works (test from #189 unaffected)
- UI now uses POST