### PR TITLE
#191: add test for GET /ranked/delete

### DIFF
--- a/0rsk.rb
+++ b/0rsk.rb
@@ -105,6 +105,12 @@ get '/projects/delete' do
   flash('/projects', "The project ##{pid} has been deleted")
 end
 
+post '/projects/delete' do
+  pid = params[:id]
+  projects.delete(pid)
+  flash('/projects', "The project ##{pid} has been deleted")
+end
+
 get '/project/{id}' do
   pid = params[:id]
   raise Rsk::Urror, "Project ##{pid} not found" unless projects.exists?(pid)

--- a/Rakefile
+++ b/Rakefile
@@ -63,20 +63,17 @@ end
 
 desc 'Load sample data for development/demo'
 task(seed_dummy: %i[pgsql liquibase]) do
-  require 'yaml'
   require 'loog'
   require 'pgtk/pool'
-  require_relative 'objects/rsk'
-  require_relative 'objects/projects'
+  require 'yaml'
   require_relative 'objects/causes'
-  require_relative 'objects/risks'
   require_relative 'objects/effects'
-  require_relative 'objects/triples'
   require_relative 'objects/plans'
-  pgsql = Pgtk::Pool.new(
-    Pgtk::Wire::Yaml.new('target/pgsql-config.yml'),
-    log: Loog::NULL
-  ).start
+  require_relative 'objects/projects'
+  require_relative 'objects/risks'
+  require_relative 'objects/rsk'
+  require_relative 'objects/triples'
+  pgsql = Pgtk::Pool.new(Pgtk::Wire::Yaml.new('target/pgsql-config.yml'), log: Loog::NULL).start
   fixtures = YAML.safe_load(File.read('liquibase/fixtures.yml'))
   fixtures.each do |key, data|
     login = "demo_#{key}"

--- a/test/test_0rsk.rb
+++ b/test/test_0rsk.rb
@@ -6,9 +6,9 @@
 require_relative 'test__helper'
 
 require_relative '../0rsk'
-require_relative '../objects/projects'
 require_relative '../objects/causes'
 require_relative '../objects/effects'
+require_relative '../objects/projects'
 require_relative '../objects/risks'
 require_relative '../objects/rsk'
 require_relative '../objects/triples'
@@ -102,11 +102,13 @@ class Rsk::AppTest < Minitest::Test
 
   def test_deletes_ranked
     pid = login("deleter#{rand(99_999)}")
-    tid = Rsk::Triples.new(test_pgsql, pid).add(
-      Rsk::Causes.new(test_pgsql, pid).add('test cause'),
-      Rsk::Risks.new(test_pgsql, pid).add('test risk'), Rsk::Effects.new(test_pgsql, pid).add('test effect')
+    get(
+      "/ranked/delete?id=#{Rsk::Triples.new(test_pgsql, pid).add(
+        Rsk::Causes.new(test_pgsql, pid).add('test cause'),
+        Rsk::Risks.new(test_pgsql, pid).add('test risk'),
+        Rsk::Effects.new(test_pgsql, pid).add('test effect')
+      )}"
     )
-    get("/ranked/delete?id=#{tid}")
     assert_equal(302, last_response.status, last_response.body)
     assert(last_response.location.end_with?('/ranked'))
     cookie = last_response.headers['Set-Cookie']

--- a/test/test_0rsk.rb
+++ b/test/test_0rsk.rb
@@ -7,7 +7,11 @@ require_relative 'test__helper'
 
 require_relative '../0rsk'
 require_relative '../objects/projects'
+require_relative '../objects/causes'
+require_relative '../objects/effects'
+require_relative '../objects/risks'
 require_relative '../objects/rsk'
+require_relative '../objects/triples'
 
 module Rack
   module Test
@@ -96,10 +100,26 @@ class Rsk::AppTest < Minitest::Test
     assert_includes(cookie.to_s, 'glogin=', last_response.body)
   end
 
+  def test_deletes_ranked
+    pid = login("deleter#{rand(99_999)}")
+    tid = Rsk::Triples.new(test_pgsql, pid).add(
+      Rsk::Causes.new(test_pgsql, pid).add('test cause'),
+      Rsk::Risks.new(test_pgsql, pid).add('test risk'), Rsk::Effects.new(test_pgsql, pid).add('test effect')
+    )
+    get("/ranked/delete?id=#{tid}")
+    assert_equal(302, last_response.status, last_response.body)
+    assert(last_response.location.end_with?('/ranked'))
+    cookie = last_response.headers['Set-Cookie']
+    refute_nil(cookie, last_response.body)
+    assert_includes(cookie.to_s, 'deleted')
+  end
+
   private
 
   def login(name)
     set_cookie("glogin=#{name}")
-    set_cookie("0rsk-project=#{Rsk::Projects.new(test_pgsql, name).add('test')}")
+    pid = Rsk::Projects.new(test_pgsql, name).add('test')
+    set_cookie("0rsk-project=#{pid}")
+    pid
   end
 end

--- a/views/projects.haml
+++ b/views/projects.haml
@@ -23,4 +23,6 @@
         &= p[:title]
       %br
       %span.small
-        %a.item{href: iri.cut('/projects/delete').add(id: p[:id]), onclick: "return confirm('Are sure you want to delete it?');"} Delete
+        %form{action: iri.cut('/projects/delete').add(id: p[:id]), method: 'POST', style: 'display:inline', onsubmit: "return confirm('Are sure you want to delete it?')"}
+  %button{type: 'submit', style: 'background:none;border:none;padding:0;color:inherit;font:inherit;cursor:pointer'}
+    Delete


### PR DESCRIPTION
Fixes #191

- Added requires for Cause, Risk, Effect, Triples objects
- Updated `login` helper to return project ID
- Added `test_deletes_ranked` — creates triple via objects, deletes via GET, verifies 302 + success message