### PR TITLE
#192: use POST for /ranked/delete, keep GET for backward compat

### DIFF
--- a/0rsk.rb
+++ b/0rsk.rb
@@ -83,6 +83,12 @@ get '/ranked/delete' do
   flash('/ranked', "The ranked triple ##{id} deleted")
 end
 
+post '/ranked/delete' do
+  id = params[:id]
+  triples.delete(id)
+  flash('/ranked', "The ranked triple ##{id} deleted")
+end
+
 get '/projects' do
   haml :projects, layout: :layout, locals: merged(title: '/projects', projects: projects.fetch)
 end

--- a/Rakefile
+++ b/Rakefile
@@ -63,20 +63,17 @@ end
 
 desc 'Load sample data for development/demo'
 task(seed_dummy: %i[pgsql liquibase]) do
-  require 'yaml'
   require 'loog'
   require 'pgtk/pool'
-  require_relative 'objects/rsk'
-  require_relative 'objects/projects'
+  require 'yaml'
   require_relative 'objects/causes'
-  require_relative 'objects/risks'
   require_relative 'objects/effects'
-  require_relative 'objects/triples'
   require_relative 'objects/plans'
-  pgsql = Pgtk::Pool.new(
-    Pgtk::Wire::Yaml.new('target/pgsql-config.yml'),
-    log: Loog::NULL
-  ).start
+  require_relative 'objects/projects'
+  require_relative 'objects/risks'
+  require_relative 'objects/rsk'
+  require_relative 'objects/triples'
+  pgsql = Pgtk::Pool.new(Pgtk::Wire::Yaml.new('target/pgsql-config.yml'), log: Loog::NULL).start
   fixtures = YAML.safe_load(File.read('liquibase/fixtures.yml'))
   fixtures.each do |key, data|
     login = "demo_#{key}"

--- a/views/ranked.haml
+++ b/views/ranked.haml
@@ -45,7 +45,9 @@
         - else
           = "#{r[:plans].count} plan#{r[:plans].count == 1 ? '' : 's'}"
           = '&darr;'
-      %a.item.small{href: iri.cut('/ranked/delete').add(id: r[:id]), onclick: "return confirm('Are sure you want to delete triple ##{r[:id]}');"} Delete
+      %form{action: iri.cut('/ranked/delete').add(id: r[:id]), method: 'POST', style: 'display:inline', onsubmit: "return confirm('Are sure you want to delete triple ##{r[:id]}?')"}
+        %button{type: 'submit', style: 'background:none;border:none;padding:0;color:inherit;font:inherit;cursor:pointer'}
+          Delete
       - unless r[:plans].empty?
         - r[:plans].each do |p|
           %br


### PR DESCRIPTION
Fixes #192

- `0rsk.rb`: added `post /ranked/delete` handler (GET preserved for backward compat)
- `views/ranked.haml`: Delete link replaced with `<form method="POST">`, button styled as link
- `onsubmit` confirm dialog preserved
- GET /ranked/delete still works (test from #191 unaffected)
- UI now uses POST