### PR TITLE
#327 Pin three GitHub Actions from @master to specific versions

### DIFF
--- a/.github/workflows/pdd.yml
+++ b/.github/workflows/pdd.yml
@@ -16,4 +16,4 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
-      - uses: volodya-lombrozo/pdd-action@master
+      - uses: volodya-lombrozo/pdd-action@69842b56627431c5f232f5ea2dc2fca82f409c54

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -16,4 +16,4 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
-      - uses: ludeeus/action-shellcheck@master
+      - uses: ludeeus/action-shellcheck@2.0.0

--- a/.github/workflows/xcop.yml
+++ b/.github/workflows/xcop.yml
@@ -16,6 +16,6 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
-      - uses: g4s8/xcop-action@master
+      - uses: g4s8/xcop-action@v1.3
         with:
           files: '**/*.xml'

--- a/Rakefile
+++ b/Rakefile
@@ -63,20 +63,17 @@ end
 
 desc 'Load sample data for development/demo'
 task(seed_dummy: %i[pgsql liquibase]) do
-  require 'yaml'
   require 'loog'
   require 'pgtk/pool'
-  require_relative 'objects/rsk'
-  require_relative 'objects/projects'
+  require 'yaml'
   require_relative 'objects/causes'
-  require_relative 'objects/risks'
   require_relative 'objects/effects'
-  require_relative 'objects/triples'
   require_relative 'objects/plans'
-  pgsql = Pgtk::Pool.new(
-    Pgtk::Wire::Yaml.new('target/pgsql-config.yml'),
-    log: Loog::NULL
-  ).start
+  require_relative 'objects/projects'
+  require_relative 'objects/risks'
+  require_relative 'objects/rsk'
+  require_relative 'objects/triples'
+  pgsql = Pgtk::Pool.new(Pgtk::Wire::Yaml.new('target/pgsql-config.yml'), log: Loog::NULL).start
   fixtures = YAML.safe_load(File.read('liquibase/fixtures.yml'))
   fixtures.each do |key, data|
     login = "demo_#{key}"


### PR DESCRIPTION
Closes #327

Pins three GitHub Actions to pinned versions instead of @master:

- **pdd.yml**: `volodya-lombrozo/pdd-action@69842b5` (fork of `maxonfjvipon/pdd-action` — upstream Dockerfile is broken: mixes Alpine `apk` with `apt-get`, causing Docker build failures. The fork fixes these issues. Pinned to SHA because the fork has no releases.)
- **xcop.yml**: `g4s8/xcop-action@v1.3`
- **shellcheck.yml**: `ludeeus/action-shellcheck@2.0.0`