### PR TITLE
#337 Fix Ruby 4.0 CI: update faraday-multipart to 1.2.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,7 +83,7 @@ GEM
     faraday-em_synchrony (1.0.0)
     faraday-excon (1.1.0)
     faraday-httpclient (1.0.1)
-    faraday-multipart (1.1.0)
+    faraday-multipart (1.2.0)
       multipart-post (~> 2.0)
     faraday-net_http (1.0.2)
     faraday-net_http_persistent (1.2.0)
@@ -342,10 +342,12 @@ GEM
 PLATFORMS
   aarch64-linux
   arm-linux
+  arm-linux-gnu
   arm64-darwin
   arm64-darwin-23
   x64-mingw-ucrt
   x86-linux
+  x86-linux-gnu
   x86_64-darwin
   x86_64-linux
 


### PR DESCRIPTION
Fixes the Ruby 4.0.5 CI failure in the merge to master.

**Root cause:** `faraday-multipart 1.1.0` requires `ruby < 4`, incompatible with Ruby 4.0.5.

**Fix:** Bump to `faraday-multipart 1.2.0` which removed the `< 4` constraint (`>= 2.4`).

CI run with failure: https://github.com/yegor256/0rsk/actions/runs/27366118528/job/80865999730