### PR TITLE
#363 Cause#emoji= raises NoMethodError when char argument is nil

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -63,20 +63,17 @@ end
 
 desc 'Load sample data for development/demo'
 task(seed_dummy: %i[pgsql liquibase]) do
-  require 'yaml'
   require 'loog'
   require 'pgtk/pool'
-  require_relative 'objects/rsk'
-  require_relative 'objects/projects'
+  require 'yaml'
   require_relative 'objects/causes'
-  require_relative 'objects/risks'
   require_relative 'objects/effects'
-  require_relative 'objects/triples'
   require_relative 'objects/plans'
-  pgsql = Pgtk::Pool.new(
-    Pgtk::Wire::Yaml.new('target/pgsql-config.yml'),
-    log: Loog::NULL
-  ).start
+  require_relative 'objects/projects'
+  require_relative 'objects/risks'
+  require_relative 'objects/rsk'
+  require_relative 'objects/triples'
+  pgsql = Pgtk::Pool.new(Pgtk::Wire::Yaml.new('target/pgsql-config.yml'), log: Loog::NULL).start
   fixtures = YAML.safe_load(File.read('liquibase/fixtures.yml'))
   fixtures.each do |key, data|
     login = "demo_#{key}"

--- a/objects/cause.rb
+++ b/objects/cause.rb
@@ -26,6 +26,7 @@ class Rsk::Cause
   end
 
   def decorate(char)
+    raise(Rsk::Urror, 'The emoji can\'t be nil') if char.nil?
     raise(Rsk::Urror, 'The emoji must be one-symbol only') if char.length > 1
     @pgsql.exec('UPDATE cause SET emoji = $2 WHERE id = $1', [@id, char])
   end

--- a/test/test_cause.rb
+++ b/test/test_cause.rb
@@ -33,4 +33,13 @@ class Rsk::CauseTest < Minitest::Test
     cause.decorate('📚')
     assert_equal('📚', cause.emoji)
   end
+
+  def test_rejects_nil_emoji
+    causes = Rsk::Causes.new(
+      test_pgsql,
+      Rsk::Projects.new(test_pgsql, "nill#{rand(99_999)}").add("test#{rand(99_999)}")
+    )
+    cause = causes.get(causes.add('test nil'))
+    assert_raises(Rsk::Urror) { cause.decorate(nil) }
+  end
 end


### PR DESCRIPTION
Fixes #363

`Cause#emoji=` now checks for `nil` before calling `.length`,
raising `Rsk::Urror` with a descriptive message instead of
`NoMethodError`.

- `objects/cause.rb:33` — added `nil?` guard
- `test/test_cause.rb:36-41` — added `test_rejects_nil_emoji` test