### PR TITLE
#365 Triples#add does not verify that parts belong to the initialized project

### DIFF
--- a/objects/triples.rb
+++ b/objects/triples.rb
@@ -18,15 +18,25 @@ class Rsk::Triples
   end
 
   def add(cid, rid, eid)
-    @pgsql.exec(
-      [
-        'INSERT INTO triple (cause, risk, effect)',
-        'VALUES ($1, $2, $3)',
-        'ON CONFLICT(cause, risk, effect) DO UPDATE SET cause = $1',
-        'RETURNING id'
-      ],
-      [cid, rid, eid]
-    )[0]['id'].to_i
+    @pgsql.transaction do |t|
+      cnt = t.exec(
+        'SELECT COUNT(*) FROM part WHERE id IN ($1, $2, $3) AND project = $4',
+        [cid, rid, eid, @project]
+      )[0]['count'].to_i
+      if cnt < 3
+        raise Rsk::Urror,
+              "Parts ##{cid}, ##{rid}, ##{eid} must all belong to project ##{@project}"
+      end
+      t.exec(
+        [
+          'INSERT INTO triple (cause, risk, effect)',
+          'VALUES ($1, $2, $3)',
+          'ON CONFLICT(cause, risk, effect) DO UPDATE SET cause = $1',
+          'RETURNING id'
+        ],
+        [cid, rid, eid]
+      )[0]['id'].to_i
+    end
   end
 
   def delete(id)

--- a/test/test_triples.rb
+++ b/test/test_triples.rb
@@ -33,6 +33,18 @@ class Rsk::TriplesTest < Minitest::Test
     triples.fetch.each { |t| triples.delete(t[:id]) }
   end
 
+  def test_rejects_cross_project_parts
+    login = "sarahX#{rand(99_999)}"
+    project = Rsk::Projects.new(test_pgsql, login).add("test#{rand(99_999)}")
+    Rsk::Causes.new(test_pgsql, project).add('we have data')
+    rid = Rsk::Risks.new(test_pgsql, project).add('we may lose it')
+    eid = Rsk::Effects.new(test_pgsql, project).add('business will stop')
+    other = Rsk::Projects.new(test_pgsql, "sarahY#{rand(99_999)}").add("test#{rand(99_999)}")
+    cid2 = Rsk::Causes.new(test_pgsql, other).add('data from other project')
+    triples = Rsk::Triples.new(test_pgsql, project)
+    assert_raises(Rsk::Urror) { triples.add(cid2, rid, eid) }
+  end
+
   def test_fetches_with_plans
     login = "sarahP#{rand(99_999)}"
     project = Rsk::Projects.new(test_pgsql, login).add("test#{rand(99_999)}")


### PR DESCRIPTION
Fixes #365

`Triples#add` now verifies that all three part IDs (cause, risk, effect) belong to the initialized `@project` before inserting, raising `Rsk::Urror` with a descriptive message if any does not.

- `objects/triples.rb:20-40` — wrapped insert in a transaction with a `SELECT COUNT(*) ... IN (,,)` ownership check
- `test/test_triples.rb:36-46` — added `test_rejects_cross_project_parts`