### PR TITLE
#370: raise Rsk::Urror instead of silently postponing by 1 second for unknown period

### DIFF
--- a/front/front_tasks.rb
+++ b/front/front_tasks.rb
@@ -5,6 +5,7 @@ require_relative '../objects/pipeline'
 # SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
+require_relative '../objects/postpone'
 require_relative '../objects/tasks'
 
 Rsk::Daemon.new(10).start do
@@ -39,11 +40,7 @@ end
 
 get '/tasks/later' do
   id = Integer(params[:id])
-  seconds = 1
-  seconds *= 7 * 24 * 60 * 60 if params[:period] == 'week'
-  seconds *= 30 * 24 * 60 * 60 if params[:period] == 'month'
-  seconds *= 3 * 30 * 24 * 60 * 60 if params[:period] == 'quarter'
-  tasks.postpone(id, seconds)
+  tasks.postpone(id, Rsk::Postpone.seconds(params[:period]))
   flash('/tasks', "Thanks, the task ##{id} was postponed")
 end
 

--- a/front/front_tasks.rb
+++ b/front/front_tasks.rb
@@ -40,7 +40,7 @@ end
 
 get '/tasks/later' do
   id = Integer(params[:id])
-  tasks.postpone(id, Rsk::Postpone.seconds(params[:period]))
+  tasks.postpone(id, Rsk::Postpone.new(params[:period]).seconds)
   flash('/tasks', "Thanks, the task ##{id} was postponed")
 end
 

--- a/objects/postpone.rb
+++ b/objects/postpone.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'rsk'
+require_relative 'urror'
+
+module Rsk::Postpone
+  PERIODS = { 'week' => 7 * 24 * 60 * 60, 'month' => 30 * 24 * 60 * 60, 'quarter' => 3 * 30 * 24 * 60 * 60 }.freeze
+
+  def self.seconds(period)
+    Rsk::Postpone::PERIODS.fetch(period) do
+      raise(Rsk::Urror, "Unknown postpone period: #{period.inspect}")
+    end
+  end
+end

--- a/objects/postpone.rb
+++ b/objects/postpone.rb
@@ -6,12 +6,16 @@
 require_relative 'rsk'
 require_relative 'urror'
 
-module Rsk::Postpone
+class Rsk::Postpone
   PERIODS = { 'week' => 7 * 24 * 60 * 60, 'month' => 30 * 24 * 60 * 60, 'quarter' => 3 * 30 * 24 * 60 * 60 }.freeze
 
-  def self.seconds(period)
-    Rsk::Postpone::PERIODS.fetch(period) do
-      raise(Rsk::Urror, "Unknown postpone period: #{period.inspect}")
+  def initialize(period)
+    @period = period
+  end
+
+  def seconds
+    Rsk::Postpone::PERIODS.fetch(@period) do
+      raise(Rsk::Urror, "Unknown postpone period: #{@period.inspect}")
     end
   end
 end

--- a/test/test_postpone.rb
+++ b/test/test_postpone.rb
@@ -9,22 +9,22 @@ require_relative 'test__helper'
 
 class Rsk::PostponeTest < Minitest::Test
   def test_resolves_week
-    assert_equal(7 * 24 * 60 * 60, Rsk::Postpone.seconds('week'))
+    assert_equal(7 * 24 * 60 * 60, Rsk::Postpone.new('week').seconds)
   end
 
   def test_resolves_month
-    assert_equal(30 * 24 * 60 * 60, Rsk::Postpone.seconds('month'))
+    assert_equal(30 * 24 * 60 * 60, Rsk::Postpone.new('month').seconds)
   end
 
   def test_resolves_quarter
-    assert_equal(3 * 30 * 24 * 60 * 60, Rsk::Postpone.seconds('quarter'))
+    assert_equal(3 * 30 * 24 * 60 * 60, Rsk::Postpone.new('quarter').seconds)
   end
 
   def test_raises_on_unknown_period
-    assert_raises(Rsk::Urror) { Rsk::Postpone.seconds('year') }
+    assert_raises(Rsk::Urror) { Rsk::Postpone.new('year').seconds }
   end
 
   def test_raises_on_missing_period
-    assert_raises(Rsk::Urror) { Rsk::Postpone.seconds(nil) }
+    assert_raises(Rsk::Urror) { Rsk::Postpone.new(nil).seconds }
   end
 end

--- a/test/test_postpone.rb
+++ b/test/test_postpone.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require_relative '../objects/postpone'
+require_relative '../objects/urror'
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'test__helper'
+
+class Rsk::PostponeTest < Minitest::Test
+  def test_resolves_week
+    assert_equal(7 * 24 * 60 * 60, Rsk::Postpone.seconds('week'))
+  end
+
+  def test_resolves_month
+    assert_equal(30 * 24 * 60 * 60, Rsk::Postpone.seconds('month'))
+  end
+
+  def test_resolves_quarter
+    assert_equal(3 * 30 * 24 * 60 * 60, Rsk::Postpone.seconds('quarter'))
+  end
+
+  def test_raises_on_unknown_period
+    assert_raises(Rsk::Urror) { Rsk::Postpone.seconds('year') }
+  end
+
+  def test_raises_on_missing_period
+    assert_raises(Rsk::Urror) { Rsk::Postpone.seconds(nil) }
+  end
+end


### PR DESCRIPTION
`GET /tasks/later` in `front/front_tasks.rb` initialized `seconds = 1` and only multiplied it
for `week`/`month`/`quarter`, so any missing or unrecognized `period` parameter silently
postponed a task by one second while still showing the "Thanks, the task was postponed" flash
message — the task then reappeared in the pipeline almost immediately, per #370.

Extracted the period-to-seconds mapping into a new `Rsk::Postpone` module in `objects/`
(matching this repo's convention of keeping testable logic in `objects/` and thin route glue in
`front/`), with a `Hash#fetch` default block that raises `Rsk::Urror` for any period outside
`week`/`month`/`quarter`. The route now calls `Rsk::Postpone.seconds(params[:period])`, and an
unrecognized period is caught by the app's existing generic `Rsk::Urror` handler in
`front/front_misc.rb`, which redirects with a flash error message instead of silently postponing.

Added `test/test_postpone.rb` covering all three valid periods, an unknown period, and a missing
(`nil`) period.

Ran `rubocop` on the three changed/added files locally (no offenses) and verified the module's
behavior directly with `ruby -e` (all three periods resolve to the expected second counts, and
both an unknown and a missing period raise `Rsk::Urror`) since the full test suite needs a local
Postgres instance not available in this environment.

Closes #370
