### PR TITLE
#193: Replace jQuery with native JavaScript

### DIFF
--- a/public/js/dom.js
+++ b/public/js/dom.js
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+// SPDX-License-Identifier: MIT
+
+function dom_by_id(id) {
+  "use strict";
+  return document.getElementById(id);
+}
+
+function dom_show(element) {
+  "use strict";
+  element.style.display = "";
+}
+
+function dom_hide(element) {
+  "use strict";
+  element.style.display = "none";
+}

--- a/public/js/responses.js
+++ b/public/js/responses.js
@@ -1,22 +1,36 @@
 // SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
 // SPDX-License-Identifier: MIT
 
-/*global $, dateFns */
+/*global dateFns */
+
+function by_id(id) {
+  "use strict";
+  return document.getElementById(id);
+}
 
 function on_schedule(label, f) {
   "use strict";
-  document.getElementById("schedule_" + label).addEventListener("click", function() {
-    document.getElementById("schedule").value = dateFns.format(f(new Date()), "DD-MM-YYYY");
-    return false;
+  var link = by_id("schedule_" + label);
+  var schedule = by_id("schedule");
+  if (!link || !schedule) {
+    return;
+  }
+  link.addEventListener("click", function(event) {
+    event.preventDefault();
+    schedule.value = dateFns.format(f(new Date()), "DD-MM-YYYY");
   });
 }
 
 function on_mnemo(id) {
   "use strict";
-  var span = document.getElementById(id);
-  span.addEventListener("click", function() {
-    document.getElementById("schedule").value = span.textContent;
-    return false;
+  var link = by_id(id);
+  var schedule = by_id("schedule");
+  if (!link || !schedule) {
+    return;
+  }
+  link.addEventListener("click", function(event) {
+    event.preventDefault();
+    schedule.value = link.textContent;
   });
 }
 

--- a/public/js/responses.js
+++ b/public/js/responses.js
@@ -5,22 +5,22 @@
 
 function on_schedule(label, f) {
   "use strict";
-  $("#schedule_" + label).on("click", function() {
-    $("#schedule").val(dateFns.format(f(new Date()), "DD-MM-YYYY"));
+  document.getElementById("schedule_" + label).addEventListener("click", function() {
+    document.getElementById("schedule").value = dateFns.format(f(new Date()), "DD-MM-YYYY");
     return false;
   });
 }
 
 function on_mnemo(id) {
   "use strict";
-  var $span = $("#" + id);
-  $span.on("click", function() {
-    $("#schedule").val($span.text());
+  var span = document.getElementById(id);
+  span.addEventListener("click", function() {
+    document.getElementById("schedule").value = span.textContent;
     return false;
   });
 }
 
-$(function() {
+document.addEventListener("DOMContentLoaded", function() {
   "use strict";
   on_schedule("asap", function(today) { return dateFns.addDays(today, 2); });
   on_schedule("week", function(today) { return dateFns.addDays(today, 4); });

--- a/public/js/responses.js
+++ b/public/js/responses.js
@@ -1,17 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
 // SPDX-License-Identifier: MIT
 
-/*global dateFns */
-
-function by_id(id) {
-  "use strict";
-  return document.getElementById(id);
-}
+/*global dateFns, dom_by_id */
 
 function on_schedule(label, f) {
   "use strict";
-  var link = by_id("schedule_" + label);
-  var schedule = by_id("schedule");
+  var link = dom_by_id("schedule_" + label);
+  var schedule = dom_by_id("schedule");
   if (!link || !schedule) {
     return;
   }
@@ -23,8 +18,8 @@ function on_schedule(label, f) {
 
 function on_mnemo(id) {
   "use strict";
-  var link = by_id(id);
-  var schedule = by_id("schedule");
+  var link = dom_by_id(id);
+  var schedule = dom_by_id("schedule");
   if (!link || !schedule) {
     return;
   }

--- a/public/js/triple.js
+++ b/public/js/triple.js
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
 // SPDX-License-Identifier: MIT
 
+/*global dateFns */
+
 function by_id(id) {
   "use strict";
   return document.getElementById(id);

--- a/public/js/triple.js
+++ b/public/js/triple.js
@@ -1,63 +1,204 @@
 // SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
 // SPDX-License-Identifier: MIT
 
-/*global $, dateFns */
+function by_id(id) {
+  "use strict";
+  return document.getElementById(id);
+}
+
+function show(element) {
+  "use strict";
+  element.style.display = "";
+}
+
+function hide(element) {
+  "use strict";
+  element.style.display = "none";
+}
+
+function trigger_change(element) {
+  "use strict";
+  element.dispatchEvent(new Event("change", { bubbles: true }));
+}
+
+function apply_fields(fields) {
+  "use strict";
+  Object.keys(fields).forEach(function(field) {
+    var element = by_id(field);
+    if (!element) {
+      return;
+    }
+    if (typeof fields[field] === "boolean") {
+      element.checked = fields[field];
+    } else {
+      element.value = fields[field];
+    }
+    trigger_change(element);
+  });
+}
+
+function item_text(item) {
+  "use strict";
+  return item.label || item.value || item.text || "";
+}
 
 function auto(kind, uri) {
   "use strict";
-  var $input = $("#" + kind);
-  $input.on("input", function() {
-    $("#" + kind + "_detach").addClass("red");
+  var input = by_id(kind);
+  var detach = by_id(kind + "_detach");
+  var timer = null;
+  var list = document.createElement("ul");
+  list.style.display = "none";
+  list.style.position = "absolute";
+  list.style.zIndex = "1000";
+  list.style.margin = "0";
+  list.style.padding = ".2em .4em";
+  list.style.listStyle = "none";
+  list.style.border = "1px solid #999";
+  list.style.background = "Canvas";
+  list.style.color = "CanvasText";
+  input.insertAdjacentElement("afterend", list);
+
+  function close() {
+    hide(list);
+    list.replaceChildren();
+  }
+
+  function select(item) {
+    if (item.fields) {
+      apply_fields(item.fields);
+    }
+    show(detach);
+    detach.classList.remove("red");
+    close();
+  }
+
+  function render(items) {
+    close();
+    items.forEach(function(item) {
+      var option = document.createElement("li");
+      var button = document.createElement("button");
+      button.type = "button";
+      button.textContent = item_text(item);
+      button.style.background = "none";
+      button.style.border = "0";
+      button.style.color = "inherit";
+      button.style.cursor = "pointer";
+      button.style.display = "block";
+      button.style.font = "inherit";
+      button.style.padding = ".2em";
+      button.style.textAlign = "left";
+      button.style.width = "100%";
+      button.addEventListener("click", function() {
+        select(item);
+      });
+      option.appendChild(button);
+      list.appendChild(option);
+    });
+    if (items.length > 0) {
+      show(list);
+    }
+  }
+
+  function search() {
+    fetch(uri + "?query=" + encodeURIComponent(input.value), {
+      headers: { Accept: "application/json" }
+    }).then(function(response) {
+      if (!response.ok) {
+        return [];
+      }
+      return response.json();
+    }).then(render).catch(close);
+  }
+
+  input.addEventListener("input", function() {
+    detach.classList.add("red");
+    clearTimeout(timer);
+    timer = setTimeout(search, 300);
   });
-  var closing = false;
-  $input.autocomplete({
-    minLength: 0,
-    delay: 300,
-    source: function(request, response) {
-      $.ajax({
-        url: uri,
-        method: "GET",
-        dataType: "json",
-        data: { query: request.term },
-        success: function(data) {
-          response(data);
-        }
-      });
-    },
-    select: function(event, ui) {
-      $.each(ui.item.fields, function(field, v) {
-        var $field = $("#" + field);
-        if (typeof v === "boolean") {
-          $field.prop("checked", v);
-        } else {
-          $field.val(v);
-        }
-        $field.trigger("change");
-        $("#" + kind + "_detach").show().removeClass("red");
-      });
-    },
-    close: function() {
-      closing = true;
-      setTimeout(function() { closing = false; }, 300);
+  input.addEventListener("focus", search);
+  input.addEventListener("keydown", function(event) {
+    if (event.key === "Escape") {
+      close();
     }
   });
-  $input.focus(function() {
-    if (!closing) {
-      $(this).autocomplete("search");
+  document.addEventListener("click", function(event) {
+    if (event.target !== input && !list.contains(event.target)) {
+      close();
     }
   });
 }
 
 function on_detach(button, id) {
   "use strict";
-  $(button).on("click", function() {
-    $(id).val("");
-    $(this).hide();
-    return false;
+  var link = document.querySelector(button);
+  var input = document.querySelector(id);
+  if (!link || !input) {
+    return;
+  }
+  link.addEventListener("click", function(event) {
+    event.preventDefault();
+    input.value = "";
+    hide(link);
   });
 }
 
-$(function() {
+function on_positive() {
+  "use strict";
+  var positive = by_id("positive");
+  var marker = by_id("marker");
+  var impact = by_id("impact");
+  if (!positive || !marker || !impact) {
+    return;
+  }
+  positive.addEventListener("change", function() {
+    var yes = positive.checked;
+    marker.classList.toggle("up", yes);
+    marker.classList.toggle("down", !yes);
+    impact.querySelectorAll('option[type="negative"]').forEach(function(option) {
+      option.hidden = yes;
+    });
+    impact.querySelectorAll('option[type="positive"]').forEach(function(option) {
+      option.hidden = !yes;
+    });
+    impact.value = 5;
+  });
+}
+
+function on_emojis() {
+  "use strict";
+  var emoji = by_id("emoji");
+  if (!emoji) {
+    return;
+  }
+  document.querySelectorAll("a.emoji").forEach(function(link) {
+    link.addEventListener("click", function(event) {
+      event.preventDefault();
+      emoji.value = link.textContent;
+    });
+  });
+}
+
+function on_submit() {
+  "use strict";
+  var form = document.querySelector('form[action$="/triple/save"]');
+  if (!form) {
+    return;
+  }
+  form.addEventListener("submit", function(event) {
+    if (
+      by_id("cid").value ||
+      by_id("rid").value ||
+      by_id("eid").value
+    ) {
+      if (!confirm("You are going to MODIFY existing data, are you sure?")) {
+        event.preventDefault();
+      }
+    }
+  });
+}
+
+document.addEventListener("DOMContentLoaded", function() {
   "use strict";
   auto("ctext", "/causes.json");
   auto("rtext", "/risks.json");
@@ -65,17 +206,7 @@ $(function() {
   on_detach("#ctext_detach", "#cid");
   on_detach("#rtext_detach", "#rid");
   on_detach("#etext_detach", "#eid");
-  $('#positive').change(function() {
-    if ($(this).is(':checked')) {
-      $('#marker').addClass('up').removeClass('down');
-      $('#impact option[type="negative"]').attr('hidden', true);
-      $('#impact option[type="positive"]').attr('hidden', false);
-      $('#impact').val(5);
-    } else {
-      $('#marker').addClass('down').removeClass('up');
-      $('#impact option[type="negative"]').attr('hidden', false);
-      $('#impact option[type="positive"]').attr('hidden', true);
-      $('#impact').val(5);
-    }
-  });
+  on_positive();
+  on_emojis();
+  on_submit();
 });

--- a/public/js/triple.js
+++ b/public/js/triple.js
@@ -1,22 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
 // SPDX-License-Identifier: MIT
 
-/*global dateFns */
+/*global dom_by_id, dom_hide, dom_show */
 
-function by_id(id) {
-  "use strict";
-  return document.getElementById(id);
-}
-
-function show(element) {
-  "use strict";
-  element.style.display = "";
-}
-
-function hide(element) {
-  "use strict";
-  element.style.display = "none";
-}
+var autocomplete_widgets = [];
 
 function trigger_change(element) {
   "use strict";
@@ -26,7 +13,7 @@ function trigger_change(element) {
 function apply_fields(fields) {
   "use strict";
   Object.keys(fields).forEach(function(field) {
-    var element = by_id(field);
+    var element = dom_by_id(field);
     if (!element) {
       return;
     }
@@ -44,53 +31,82 @@ function item_text(item) {
   return item.label || item.value || item.text || "";
 }
 
+function close_autocomplete_widgets(event) {
+  "use strict";
+  autocomplete_widgets.forEach(function(widget) {
+    if (
+      event &&
+      (event.target === widget.input || widget.list.contains(event.target))
+    ) {
+      return;
+    }
+    widget.close();
+  });
+}
+
 function auto(kind, uri) {
   "use strict";
-  var input = by_id(kind);
-  var detach = by_id(kind + "_detach");
+  var input = dom_by_id(kind);
+  var detach = dom_by_id(kind + "_detach");
   var timer = null;
+  var closing = false;
+  var items = [];
+  var active = -1;
   var list = document.createElement("ul");
-  list.style.display = "none";
-  list.style.position = "absolute";
-  list.style.zIndex = "1000";
-  list.style.margin = "0";
-  list.style.padding = ".2em .4em";
-  list.style.listStyle = "none";
-  list.style.border = "1px solid #999";
-  list.style.background = "Canvas";
-  list.style.color = "CanvasText";
+  if (!input || !detach) {
+    return;
+  }
+  list.className = "autocomplete";
+  list.id = kind + "_autocomplete";
+  list.setAttribute("role", "listbox");
+  input.setAttribute("aria-autocomplete", "list");
+  input.setAttribute("aria-controls", list.id);
   input.insertAdjacentElement("afterend", list);
 
   function close() {
-    hide(list);
+    list.classList.remove("open");
     list.replaceChildren();
+    items = [];
+    active = -1;
+    input.removeAttribute("aria-activedescendant");
+    closing = true;
+    setTimeout(function() { closing = false; }, 300);
+  }
+
+  function activate(index) {
+    active = index;
+    list.querySelectorAll("button").forEach(function(button, pos) {
+      var selected = pos === active;
+      button.classList.toggle("active", selected);
+      button.setAttribute("aria-selected", selected ? "true" : "false");
+      if (selected) {
+        input.setAttribute("aria-activedescendant", button.id);
+      }
+    });
   }
 
   function select(item) {
     if (item.fields) {
       apply_fields(item.fields);
     }
-    show(detach);
+    dom_show(detach);
     detach.classList.remove("red");
     close();
   }
 
-  function render(items) {
+  function render(found) {
     close();
-    items.forEach(function(item) {
+    items = found.filter(function(item) {
+      return item_text(item);
+    });
+    items.forEach(function(item, index) {
       var option = document.createElement("li");
       var button = document.createElement("button");
       button.type = "button";
+      button.id = kind + "_autocomplete_" + index;
       button.textContent = item_text(item);
-      button.style.background = "none";
-      button.style.border = "0";
-      button.style.color = "inherit";
-      button.style.cursor = "pointer";
-      button.style.display = "block";
-      button.style.font = "inherit";
-      button.style.padding = ".2em";
-      button.style.textAlign = "left";
-      button.style.width = "100%";
+      button.setAttribute("role", "option");
+      button.setAttribute("aria-selected", "false");
       button.addEventListener("click", function() {
         select(item);
       });
@@ -98,7 +114,7 @@ function auto(kind, uri) {
       list.appendChild(option);
     });
     if (items.length > 0) {
-      show(list);
+      list.classList.add("open");
     }
   }
 
@@ -118,16 +134,30 @@ function auto(kind, uri) {
     clearTimeout(timer);
     timer = setTimeout(search, 300);
   });
-  input.addEventListener("focus", search);
+  input.addEventListener("focus", function() {
+    if (!closing) {
+      search();
+    }
+  });
   input.addEventListener("keydown", function(event) {
-    if (event.key === "Escape") {
+    if (event.key === "ArrowDown" && items.length > 0) {
+      event.preventDefault();
+      activate((active + 1) % items.length);
+    } else if (event.key === "ArrowUp" && items.length > 0) {
+      event.preventDefault();
+      activate((active + items.length - 1) % items.length);
+    } else if (event.key === "Enter" && active >= 0) {
+      event.preventDefault();
+      select(items[active]);
+    } else if (event.key === "Escape") {
       close();
     }
   });
-  document.addEventListener("click", function(event) {
-    if (event.target !== input && !list.contains(event.target)) {
-      close();
-    }
+
+  autocomplete_widgets.push({
+    input: input,
+    list: list,
+    close: close
   });
 }
 
@@ -141,15 +171,15 @@ function on_detach(button, id) {
   link.addEventListener("click", function(event) {
     event.preventDefault();
     input.value = "";
-    hide(link);
+    dom_hide(link);
   });
 }
 
 function on_positive() {
   "use strict";
-  var positive = by_id("positive");
-  var marker = by_id("marker");
-  var impact = by_id("impact");
+  var positive = dom_by_id("positive");
+  var marker = dom_by_id("marker");
+  var impact = dom_by_id("impact");
   if (!positive || !marker || !impact) {
     return;
   }
@@ -169,7 +199,7 @@ function on_positive() {
 
 function on_emojis() {
   "use strict";
-  var emoji = by_id("emoji");
+  var emoji = dom_by_id("emoji");
   if (!emoji) {
     return;
   }
@@ -184,14 +214,17 @@ function on_emojis() {
 function on_submit() {
   "use strict";
   var form = document.querySelector('form[action$="/triple/save"]');
+  var cid = dom_by_id("cid");
+  var rid = dom_by_id("rid");
+  var eid = dom_by_id("eid");
   if (!form) {
     return;
   }
   form.addEventListener("submit", function(event) {
     if (
-      by_id("cid").value ||
-      by_id("rid").value ||
-      by_id("eid").value
+      (cid && cid.value) ||
+      (rid && rid.value) ||
+      (eid && eid.value)
     ) {
       if (!confirm("You are going to MODIFY existing data, are you sure?")) {
         event.preventDefault();
@@ -205,6 +238,7 @@ document.addEventListener("DOMContentLoaded", function() {
   auto("ctext", "/causes.json");
   auto("rtext", "/risks.json");
   auto("etext", "/effects.json");
+  document.addEventListener("click", close_autocomplete_widgets);
   on_detach("#ctext_detach", "#cid");
   on_detach("#rtext_detach", "#rid");
   on_detach("#etext_detach", "#eid");

--- a/views/layout.haml
+++ b/views/layout.haml
@@ -12,7 +12,6 @@
     %link{href: 'https://cdn.jsdelivr.net/gh/yegor256/tacit@gh-pages/tacit-css.min.css', rel: 'stylesheet'}
     %link{href: 'https://www.yegor256.com/css/icons.css', rel: 'stylesheet'}
     %link{rel: 'shortcut icon', href: '/favicon.svg', type: 'image/svg+xml'}
-    %script{src: 'https://code.jquery.com/jquery-3.3.1.min.js'}
     :css
       .item { margin-right: 1em; }
       .logo { width: 64px; height: 64px; }

--- a/views/layout.haml
+++ b/views/layout.haml
@@ -12,6 +12,7 @@
     %link{href: 'https://cdn.jsdelivr.net/gh/yegor256/tacit@gh-pages/tacit-css.min.css', rel: 'stylesheet'}
     %link{href: 'https://www.yegor256.com/css/icons.css', rel: 'stylesheet'}
     %link{rel: 'shortcut icon', href: '/favicon.svg', type: 'image/svg+xml'}
+    %script{src: '/js/dom.js'}
     :css
       .item { margin-right: 1em; }
       .logo { width: 64px; height: 64px; }
@@ -23,6 +24,10 @@
       .up { content:url('/up.svg'); width: 1em; height:1em; }
       .down { content:url('/down.svg'); width: 1em; height:1em; }
       .dimmed { background-color: #eee; }
+      .autocomplete { display: none; position: absolute; z-index: 1000; margin: 0; padding: .2em .4em; list-style: none; border: 1px solid #999; background: Canvas; color: CanvasText; }
+      .autocomplete.open { display: block; }
+      .autocomplete button { background: none; border: 0; color: inherit; cursor: pointer; display: block; font: inherit; padding: .2em; text-align: left; width: 100%; }
+      .autocomplete button.active { outline: 1px solid currentColor; }
       @media (max-width: 768px) {
         table { font-size: .8em; }
         nav ul { flex-direction: column; }

--- a/views/triple.haml
+++ b/views/triple.haml
@@ -1,8 +1,6 @@
 -# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
 -# SPDX-License-Identifier: MIT
 
-%link{href: 'https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.css', rel: 'stylesheet'}
-%script{src: 'https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.js'}
 %script{src: '/js/triple.js'}
 
 %div.small.right{style: 'float:right; width:200px;'}
@@ -47,7 +45,7 @@
   %input#emoji{type: 'text', name: 'emoji', size: 2, maxlength: 2, autocomplete: 'off', tabindex: 2, placeholder: '💰', value: defined?(triple) ? triple[:emoji] : '💰', required: true}
   - unless emojis.empty?
     - emojis.each do |e|
-      %a{onclick: '$("#emoji").val($(this).text());return false;', href: '#'}= e
+      %a.emoji{href: '#'}= e
   %br
   %label
     Risk:
@@ -88,7 +86,7 @@
   - else
     %img#marker.down
   %br
-  %input{type: 'submit', value: 'Submit', tabindex: 8, onclick: 'if ($("#cid").val() || $("#rid").val() || $("#eid").val()) { return confirm("You are going to MODIFY existing data, are you sure?"); }'}
+  %input{type: 'submit', value: 'Submit', tabindex: 8}
 
 %p
   If you are in doubt and need to learn more about


### PR DESCRIPTION
Closes #193.

## Summary
- Removed the global jQuery script from the shared layout.
- Removed jQuery UI from the triple form page.
- Replaced jQuery-based event handlers with native DOM APIs.
- Reimplemented triple autocomplete using `fetch()` and plain JavaScript.
- Replaced inline jQuery snippets for emoji selection and submit confirmation.

## Testing
- `node --check public/js/triple.js`
- `node --check public/js/responses.js`
- `bundle _2.5.16_ exec rake eslint`
- `bundle _2.5.16_ exec rake xcop`
- `bundle _2.5.16_ exec rake rubocop`

Full `bundle _2.5.16_ exec rake` could not be completed locally because the existing `pgtk` setup fails before tests with `undefined method fresh_start=`.