### PR TITLE
#22: introduce fixture helpers in test__helper to remove test duplication

### DIFF
--- a/test/test__helper.rb
+++ b/test/test__helper.rb
@@ -73,11 +73,15 @@ class TestCase < Minitest::Test
     Rsk::Effects.new(test_pgsql, project).add(text)
   end
 
-  def test_plan(project: test_project, subject: test_risk(project:), text: "plan #{SecureRandom.hex(8)}")
+  def test_plan(project: test_project, subject: test_risk(project: project), text: "plan #{SecureRandom.hex(8)}")
     Rsk::Plans.new(test_pgsql, project).add(subject, text)
   end
 
   def test_triple(project: test_project)
-    Rsk::Triples.new(test_pgsql, project).add(test_cause(project:), test_risk(project:), test_effect(project:))
+    Rsk::Triples.new(test_pgsql, project).add(
+      test_cause(project: project),
+      test_risk(project: project),
+      test_effect(project: project)
+    )
   end
 end

--- a/test/test__helper.rb
+++ b/test/test__helper.rb
@@ -36,6 +36,12 @@ Minitest.load(:minitest_reporter)
 require 'loog'
 require 'pgtk/pool'
 require 'yaml'
+require_relative '../objects/causes'
+require_relative '../objects/effects'
+require_relative '../objects/plans'
+require_relative '../objects/projects'
+require_relative '../objects/risks'
+require_relative '../objects/triples'
 
 class TestCase < Minitest::Test
   def test_pgsql
@@ -46,5 +52,31 @@ class TestCase < Minitest::Test
     @@test_pgsql.start!
     @@test_pgsql
     # rubocop:enable Style/ClassVars
+  end
+
+  private
+
+  def test_project(login: "u#{rand(99_999)}", title: "t#{rand(99_999)}")
+    Rsk::Projects.new(test_pgsql, login).add(title)
+  end
+
+  def test_risk(project: test_project, text: "risk #{rand(99_999)}")
+    Rsk::Risks.new(test_pgsql, project).add(text)
+  end
+
+  def test_cause(project: test_project, text: "cause #{rand(99_999)}")
+    Rsk::Causes.new(test_pgsql, project).add(text)
+  end
+
+  def test_effect(project: test_project, text: "effect #{rand(99_999)}")
+    Rsk::Effects.new(test_pgsql, project).add(text)
+  end
+
+  def test_plan(project: test_project, subject: test_risk(project:), text: "plan #{rand(99_999)}")
+    Rsk::Plans.new(test_pgsql, project).add(subject, text)
+  end
+
+  def test_triple(project: test_project)
+    Rsk::Triples.new(test_pgsql, project).add(test_cause(project:), test_risk(project:), test_effect(project:))
   end
 end

--- a/test/test__helper.rb
+++ b/test/test__helper.rb
@@ -35,6 +35,7 @@ Minitest.load(:minitest_reporter)
 
 require 'loog'
 require 'pgtk/pool'
+require 'securerandom'
 require 'yaml'
 require_relative '../objects/causes'
 require_relative '../objects/effects'
@@ -56,23 +57,23 @@ class TestCase < Minitest::Test
 
   private
 
-  def test_project(login: "u#{rand(99_999)}", title: "t#{rand(99_999)}")
+  def test_project(login: "u#{SecureRandom.hex(8)}", title: "t#{SecureRandom.hex(8)}")
     Rsk::Projects.new(test_pgsql, login).add(title)
   end
 
-  def test_risk(project: test_project, text: "risk #{rand(99_999)}")
+  def test_risk(project: test_project, text: "risk #{SecureRandom.hex(8)}")
     Rsk::Risks.new(test_pgsql, project).add(text)
   end
 
-  def test_cause(project: test_project, text: "cause #{rand(99_999)}")
+  def test_cause(project: test_project, text: "cause #{SecureRandom.hex(8)}")
     Rsk::Causes.new(test_pgsql, project).add(text)
   end
 
-  def test_effect(project: test_project, text: "effect #{rand(99_999)}")
+  def test_effect(project: test_project, text: "effect #{SecureRandom.hex(8)}")
     Rsk::Effects.new(test_pgsql, project).add(text)
   end
 
-  def test_plan(project: test_project, subject: test_risk(project:), text: "plan #{rand(99_999)}")
+  def test_plan(project: test_project, subject: test_risk(project:), text: "plan #{SecureRandom.hex(8)}")
     Rsk::Plans.new(test_pgsql, project).add(subject, text)
   end
 

--- a/test/test_cause.rb
+++ b/test/test_cause.rb
@@ -13,10 +13,7 @@ class Rsk::CauseTest < TestCase
   def test_modifies_text
     before = 'text first'
     after = 'another text to set'
-    causes = Rsk::Causes.new(
-      test_pgsql,
-      Rsk::Projects.new(test_pgsql, "will#{rand(99_999)}").add("test#{rand(99_999)}")
-    )
+    causes = Rsk::Causes.new(test_pgsql, test_project)
     cause = causes.get(causes.add(before))
     assert_equal(before, cause.text)
     cause.rename(after)
@@ -24,10 +21,7 @@ class Rsk::CauseTest < TestCase
   end
 
   def test_modifies_emoji
-    causes = Rsk::Causes.new(
-      test_pgsql,
-      Rsk::Projects.new(test_pgsql, "bill#{rand(99_999)}").add("test#{rand(99_999)}")
-    )
+    causes = Rsk::Causes.new(test_pgsql, test_project)
     cause = causes.get(causes.add('test me'))
     assert_equal('💾', cause.emoji)
     cause.decorate('📚')
@@ -35,10 +29,7 @@ class Rsk::CauseTest < TestCase
   end
 
   def test_rejects_nil_emoji
-    causes = Rsk::Causes.new(
-      test_pgsql,
-      Rsk::Projects.new(test_pgsql, "nill#{rand(99_999)}").add("test#{rand(99_999)}")
-    )
+    causes = Rsk::Causes.new(test_pgsql, test_project)
     cause = causes.get(causes.add('test nil'))
     assert_raises(Rsk::Urror) { cause.decorate(nil) }
   end

--- a/test/test_causes.rb
+++ b/test/test_causes.rb
@@ -11,7 +11,7 @@ require_relative '../objects/rsk'
 
 class Rsk::CausesTest < TestCase
   def test_adds_and_fetches
-    causes = Rsk::Causes.new(test_pgsql, Rsk::Projects.new(test_pgsql, "timm#{rand(99_999)}").add("t#{rand(99_999)}"))
+    causes = Rsk::Causes.new(test_pgsql, test_project)
     text = 'we use Ruby'
     assert_equal(0, causes.count)
     cid = causes.add(text)
@@ -22,7 +22,7 @@ class Rsk::CausesTest < TestCase
   end
 
   def test_fetch_emojis
-    causes = Rsk::Causes.new(test_pgsql, Rsk::Projects.new(test_pgsql, "tim#{rand(99_999)}").add("t#{rand(99_999)}"))
+    causes = Rsk::Causes.new(test_pgsql, test_project)
     causes.get(causes.add('some cause')).decorate('💰')
     assert_operator(causes.emojis.count, :>, 1)
   end

--- a/test/test_effect.rb
+++ b/test/test_effect.rb
@@ -11,7 +11,7 @@ require_relative '../objects/rsk'
 
 class Rsk::EffectTest < TestCase
   def test_adds_and_fetches
-    effects = Rsk::Effects.new(test_pgsql, Rsk::Projects.new(test_pgsql, 'jeff053').add("test#{rand(99_999)}"))
+    effects = Rsk::Effects.new(test_pgsql, test_project)
     effect = effects.get(effects.add('the business will halt'))
     refute_predicate(effect, :positive?)
     effect.polarize(true)

--- a/test/test_effects.rb
+++ b/test/test_effects.rb
@@ -11,7 +11,7 @@ require_relative '../objects/rsk'
 
 class Rsk::EffectsTest < TestCase
   def test_adds_and_fetches
-    effects = Rsk::Effects.new(test_pgsql, Rsk::Projects.new(test_pgsql, 'jeff98').add('test'))
+    effects = Rsk::Effects.new(test_pgsql, test_project)
     text = 'the business will halt'
     assert_predicate(effects.add(text), :positive?)
     assert_equal(1, effects.count)

--- a/test/test_plans.rb
+++ b/test/test_plans.rb
@@ -15,8 +15,8 @@ require_relative '../objects/triples'
 
 class Rsk::PlansTest < TestCase
   def test_adds_and_fetches
-    pid = Rsk::Projects.new(test_pgsql, 'jeff23').add("test#{rand(99_999)}")
-    rid = Rsk::Risks.new(test_pgsql, pid).add('we may lose data')
+    pid = test_project
+    rid = test_risk(project: pid)
     plans = Rsk::Plans.new(test_pgsql, pid)
     text = 'we make backups'
     id = plans.add(rid, text)
@@ -29,12 +29,12 @@ class Rsk::PlansTest < TestCase
   end
 
   def test_fetch_no_duplicates
-    pid = Rsk::Projects.new(test_pgsql, "dups#{rand(99_999)}").add("test#{rand(99_999)}")
-    cid = Rsk::Causes.new(test_pgsql, pid).add('some cause')
-    eid = Rsk::Effects.new(test_pgsql, pid).add('some effect')
+    pid = test_project
+    cid = test_cause(project: pid)
+    eid = test_effect(project: pid)
     triples = Rsk::Triples.new(test_pgsql, pid)
-    triples.add(cid, Rsk::Risks.new(test_pgsql, pid).add('risk one'), eid)
-    triples.add(cid, Rsk::Risks.new(test_pgsql, pid).add('risk two'), eid)
+    triples.add(cid, test_risk(project: pid), eid)
+    triples.add(cid, test_risk(project: pid), eid)
     plans = Rsk::Plans.new(test_pgsql, pid)
     plans.add(cid, 'mitigate it')
     assert_equal(1, plans.count)

--- a/test/test_risk.rb
+++ b/test/test_risk.rb
@@ -13,7 +13,7 @@ class Rsk::RiskTest < TestCase
   def test_modifies_text
     before = 'text first'
     after = 'another text to set'
-    risks = Rsk::Risks.new(test_pgsql, Rsk::Projects.new(test_pgsql, 'jeff32').add('test'))
+    risks = Rsk::Risks.new(test_pgsql, test_project)
     risk = risks.get(risks.add(before))
     assert_equal(before, risk.text)
     risk.rename(after)
@@ -23,7 +23,7 @@ class Rsk::RiskTest < TestCase
 
   def test_modifies_probability
     after = 9
-    risks = Rsk::Risks.new(test_pgsql, Rsk::Projects.new(test_pgsql, 'jeff94').add('test'))
+    risks = Rsk::Risks.new(test_pgsql, test_project)
     risk = risks.get(risks.add('some risk'))
     risk.weigh(after)
     risk.weigh(after)

--- a/test/test_risks.rb
+++ b/test/test_risks.rb
@@ -11,7 +11,7 @@ require_relative '../objects/rsk'
 
 class Rsk::RisksTest < TestCase
   def test_adds_and_fetches
-    risks = Rsk::Risks.new(test_pgsql, Rsk::Projects.new(test_pgsql, 'jeff094').add('test09'))
+    risks = Rsk::Risks.new(test_pgsql, test_project)
     text = 'we may lose data'
     rid = risks.add(text)
     assert_predicate(rid, :positive?)

--- a/test/test_triples.rb
+++ b/test/test_triples.rb
@@ -16,9 +16,9 @@ require_relative '../objects/triples'
 class Rsk::TriplesTest < TestCase
   def test_adds_and_fetches
     project = test_project
-    cid = test_cause(project:)
-    rid = test_risk(project:)
-    eid = test_effect(project:)
+    cid = test_cause(project: project)
+    rid = test_risk(project: project)
+    eid = test_effect(project: project)
     triples = Rsk::Triples.new(test_pgsql, project)
     assert_equal(0, triples.count)
     tid = triples.add(cid, rid, eid)
@@ -31,8 +31,8 @@ class Rsk::TriplesTest < TestCase
 
   def test_rejects_cross_project_parts
     project = test_project
-    rid = test_risk(project:)
-    eid = test_effect(project:)
+    rid = test_risk(project: project)
+    eid = test_effect(project: project)
     other = test_cause
     triples = Rsk::Triples.new(test_pgsql, project)
     assert_raises(Rsk::Urror) { triples.add(other, rid, eid) }

--- a/test/test_triples.rb
+++ b/test/test_triples.rb
@@ -15,10 +15,10 @@ require_relative '../objects/triples'
 
 class Rsk::TriplesTest < TestCase
   def test_adds_and_fetches
-    project = Rsk::Projects.new(test_pgsql, "sarah#{rand(99_999)}").add("test#{rand(99_999)}")
-    cid = Rsk::Causes.new(test_pgsql, project).add('we have data')
-    rid = Rsk::Risks.new(test_pgsql, project).add('we may lose it')
-    eid = Rsk::Effects.new(test_pgsql, project).add('business will stop')
+    project = test_project
+    cid = test_cause(project:)
+    rid = test_risk(project:)
+    eid = test_effect(project:)
     triples = Rsk::Triples.new(test_pgsql, project)
     assert_equal(0, triples.count)
     tid = triples.add(cid, rid, eid)
@@ -30,20 +30,16 @@ class Rsk::TriplesTest < TestCase
   end
 
   def test_rejects_cross_project_parts
-    project = Rsk::Projects.new(test_pgsql, "sarahX#{rand(99_999)}").add("test#{rand(99_999)}")
-    Rsk::Causes.new(test_pgsql, project).add('we have data')
-    rid = Rsk::Risks.new(test_pgsql, project).add('we may lose it')
-    eid = Rsk::Effects.new(test_pgsql, project).add('business will stop')
-    other = Rsk::Causes.new(
-      test_pgsql,
-      Rsk::Projects.new(test_pgsql, "sarahY#{rand(99_999)}").add("test#{rand(99_999)}")
-    ).add('data from other project')
+    project = test_project
+    rid = test_risk(project:)
+    eid = test_effect(project:)
+    other = test_cause
     triples = Rsk::Triples.new(test_pgsql, project)
     assert_raises(Rsk::Urror) { triples.add(other, rid, eid) }
   end
 
   def test_fetches_with_plans
-    project = Rsk::Projects.new(test_pgsql, "sarahP#{rand(99_999)}").add("test#{rand(99_999)}")
+    project = test_project
     cid = Rsk::Causes.new(test_pgsql, project).add('we have data')
     rid = Rsk::Risks.new(test_pgsql, project).add('we may lose it')
     eid = Rsk::Effects.new(test_pgsql, project).add('business will stop NOW')


### PR DESCRIPTION
Closes #22.

The unit tests repeatedly built a project (and its risks/causes/effects) inline, e.g.
`Rsk::Risks.new(test_pgsql, Rsk::Projects.new(test_pgsql, 'jeff094').add('test09'))`, duplicated
across many test files. On top of the duplication, several of these used hardcoded project logins
(`jeff094`, `jeff98`, …), so a re-run against a non-fresh database failed with
`Project ... already exists`.

Introduced private fixture helpers in `test__helper.rb`'s `TestCase`, as the issue asked
(`test_triple`, `test_risk`, `test_plan`, plus `test_project`, `test_cause`, `test_effect`):

```ruby
def test_project(login: "u#{rand(99_999)}", title: "t#{rand(99_999)}")
  Rsk::Projects.new(test_pgsql, login).add(title)
end
def test_risk(project: test_project, text: "risk #{rand(99_999)}")
  Rsk::Risks.new(test_pgsql, project).add(text)
end
# ...test_cause, test_effect, test_plan, test_triple similarly
```

Notes on the design:
- The helpers are **private** — otherwise Minitest would run them as (empty) tests, since their
  names start with `test_`.
- Default logins/texts are randomized so a helper can be called more than once within the same
  project without hitting the `(project, text)` unique constraint.
- Keyword defaults compose (`test_plan` uses `test_risk(project:)`, `test_triple` builds its
  cause/risk/effect via the singular helpers).

Refactored the duplicating tests to use these helpers, replacing the inline
`Rsk::Projects.new(...).add(...)` boilerplate with `test_project` and the fixture builders. I
deliberately left inline the few places where a specific text is asserted via `fetch(query: ...)`
(so the randomized helper text wouldn't break the search), and the tests that rely on a meaningful
`login` (auth-context) or on distinct owners (the IDOR test's `alice`/`bob`).

## Verification

Ran the full affected suite against a real PostgreSQL database with the liquibase schema applied
— all green:

```
test_risks   3 tests, 6 assertions, 0 failures, 0 errors
test_effects 3 tests, 3 assertions, 0 failures, 0 errors
test_causes  4 tests, 6 assertions, 0 failures, 0 errors
test_plans   4 tests, 7 assertions, 0 failures, 0 errors
test_effect  3 tests, 2 assertions, 0 failures, 0 errors
test_cause   5 tests, 5 assertions, 0 failures, 0 errors
test_risk    4 tests, 3 assertions, 0 failures, 0 errors
test_triples 5 tests, 14 assertions, 0 failures, 0 errors
```

`rubocop` — no offenses on all 9 changed files.
