### PR TITLE
#21 Part E: Validate tracker inputs, drop unused token from view, thread type param

### DIFF
--- a/0rsk.rb
+++ b/0rsk.rb
@@ -131,7 +131,7 @@ end
 post '/project/{id}/tracker/add' do
   pid = params[:id]
   raise Rsk::Urror, "Project ##{pid} not found" unless projects.exists?(pid)
-  trackers(pid: pid).add(params[:repo], params[:token])
+  trackers(pid: pid).add(params[:repo], params[:token], type: params[:type])
   flash("/project/#{pid}", 'Tracker added')
 end
 

--- a/0rsk.rb
+++ b/0rsk.rb
@@ -131,7 +131,7 @@ end
 post '/project/{id}/tracker/add' do
   pid = params[:id]
   raise Rsk::Urror, "Project ##{pid} not found" unless projects.exists?(pid)
-  trackers(pid: pid).add(params[:repo], params[:token], type: params[:type])
+  trackers(pid: pid).add(params[:repo], params[:token], type: params[:type] || 'github')
   flash("/project/#{pid}", 'Tracker added')
 end
 

--- a/objects/trackers.rb
+++ b/objects/trackers.rb
@@ -4,30 +4,32 @@
 # SPDX-License-Identifier: MIT
 
 require_relative 'rsk'
+require_relative 'urror'
 
 class Rsk::Trackers
+  REPO_PATTERN = %r{\A[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+\z}.freeze
+
   def initialize(pgsql, project)
     @pgsql = pgsql
     @project = project
   end
 
-  def add(repo, token)
+  def add(repo, token, type: 'github')
+    raise(Rsk::Urror, 'Repository must be in owner/name format') unless REPO_PATTERN.match?(repo)
+    raise(Rsk::Urror, 'Token must not be empty') if token.nil? || token.empty?
     Integer(
       @pgsql.exec(
-        'INSERT INTO tracker (project, repo, token) VALUES ($1, $2, $3) RETURNING id',
-        [@project, repo, token]
+        'INSERT INTO tracker (project, repo, token, type) VALUES ($1, $2, $3, $4) RETURNING id',
+        [@project, repo, token, type]
       )[0]['id'], 10
     )
   end
 
-  def fetch
+  def fetch(token: false)
     @pgsql.exec('SELECT * FROM tracker WHERE project = $1 ORDER BY created', [@project]).map do |r|
-      {
-        id: Integer(r['id'], 10),
-        type: r['type'],
-        repo: r['repo'],
-        created: Time.parse(r['created'])
-      }
+      h = { id: Integer(r['id'], 10), type: r['type'], repo: r['repo'], created: Time.parse(r['created']) }
+      h[:token] = r['token'] if token
+      h
     end
   end
 

--- a/objects/trackers.rb
+++ b/objects/trackers.rb
@@ -7,7 +7,7 @@ require_relative 'rsk'
 require_relative 'urror'
 
 class Rsk::Trackers
-  REPO_PATTERN = %r{\A[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+\z}.freeze
+  REPO_PATTERN = %r{\A[a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+\z}
 
   def initialize(pgsql, project)
     @pgsql = pgsql


### PR DESCRIPTION
Part E of #21, split from original #336 per review (@morphqdd).

**Changes:**
- `Trackers#add` now validates `repo` format (`owner/name`) and rejects empty tokens with `Rsk::Urror`
- `Trackers#add` accepts a `type:` keyword argument (default `github`) — the type selector in the form now actually works
- `Trackers#fetch` defaults to `token: false` (tokens are never leaked to the view layer); pass `token: true` only when the caller needs them (e.g. daemon)
- `POST /project/{id}/tracker/add` now threads `params[:type]` through to `add`

**Still open (future):**
- Encrypt tokens at rest (needs a master key design decision)