### PR TITLE
#382: Fix telegram task text quotes

### DIFF
--- a/front/front_telegram.rb
+++ b/front/front_telegram.rb
@@ -177,7 +177,7 @@ module Rsk::Telegram
           [
             "\n\n[T#{t[:id]}](https://www.0rsk.com/responses?id=#{t[:triple]})",
             "(#{t[:positive] ? '+' : '-'}#{t[:rank]})",
-            t[:text].inspect,
+            t[:text],
             "in [#{t[:title]}](https://www.0rsk.com/projects/#{t[:pid]}):",
             "#{t[:ctext]}; #{t[:rtext]}; #{t[:etext]}",
             "(#{t[:schedule]})"
@@ -190,7 +190,7 @@ module Rsk::Telegram
         list.map do |t|
           [
             "\n  `T#{t[:id]}` (#{t[:positive] ? '+' : '-'}#{t[:rank]})",
-            t[:text].inspect,
+            t[:text],
             "#{t[:ctext]}; #{t[:rtext]}; #{t[:etext]}"
           ].join(' ')
         end
@@ -198,7 +198,7 @@ module Rsk::Telegram
     else
       [
         "There are too many tasks in the list (#{list.count}), here is the top of it:\n",
-        list.take(16).map! { |t| "\n`T#{t[:id]}` (#{t[:positive] ? '+' : '-'}#{t[:rank]}) #{t[:text].inspect}" }
+        list.take(16).map! { |t| "\n`T#{t[:id]}` (#{t[:positive] ? '+' : '-'}#{t[:rank]}) #{t[:text]}" }
       ]
     end
   end

--- a/test/test_0rsk.rb
+++ b/test/test_0rsk.rb
@@ -125,6 +125,28 @@ class Rsk::AppTest < TestCase
     assert_includes(cookie.to_s, 'deleted')
   end
 
+  def test_telegram_listing_plain_text
+    listing = Object.new.extend(Rsk::Telegram).listing(
+      [
+        {
+          id: 42,
+          triple: 7,
+          positive: true,
+          rank: 3,
+          text: 'Fix "urgent" bug',
+          title: 'Project',
+          pid: 5,
+          ctext: 'Cause',
+          rtext: 'Risk',
+          etext: 'Effect',
+          schedule: 'today'
+        }
+      ]
+    ).flatten.join(' ')
+    assert_includes(listing, 'Fix "urgent" bug')
+    refute_includes(listing, '"Fix \\"urgent\\" bug"')
+  end
+
   private
 
   def login(name)


### PR DESCRIPTION
Fixes #382.

This removes `String#inspect` from Telegram task list rendering so task text is shown as plain text instead of being wrapped in double quotes or escaped.

A regression test covers task text containing quotes.