### PR TITLE
#395 Avoid pooled connection reuse in Tasks#postpone

### DIFF
--- a/objects/tasks.rb
+++ b/objects/tasks.rb
@@ -35,9 +35,15 @@ class Rsk::Tasks
     row = plan(id)
     @pgsql.transaction do |t|
       t.exec('DELETE FROM task WHERE id = $1', [id])
-      plan = Rsk::Plans.new(@pgsql, Integer(row['project'] || 0)).get(Integer(row['id']), Integer(row['part']))
-      raise(Rsk::Urror, "Can't postpone plan ##{row['id']}") if /^[a-z]+$/.match?(plan.schedule)
-      plan.reschedule((Time.now + seconds).strftime('%d-%m-%Y'))
+      schedule = t.exec(
+        'SELECT schedule FROM plan WHERE id = $1 AND part = $2',
+        [row['id'], row['part']]
+      )[0]['schedule']
+      raise(Rsk::Urror, "Can't postpone plan ##{row['id']}") if /^[a-z]+$/.match?(schedule)
+      t.exec(
+        'UPDATE plan SET schedule = $3 WHERE id = $1 AND part = $2',
+        [row['id'], row['part'], (Time.now + seconds).strftime('%d-%m-%Y')]
+      )
     end
   end
 

--- a/test/test_tasks.rb
+++ b/test/test_tasks.rb
@@ -51,4 +51,55 @@ class Rsk::TasksTest < TestCase
     tasks.create
     tasks.postpone(tasks.fetch[0][:id], 60 * 60)
   end
+
+  def test_postpones_without_reusing_outer_pool_in_transaction
+    pgsql = Class.new do
+      attr_reader :updated
+
+      def initialize
+        @in_transaction = false
+      end
+
+      def exec(sql, args)
+        return exec_in_transaction(sql, args) if @in_transaction
+        outer_exec(sql)
+      end
+
+      def transaction
+        @in_transaction = true
+        yield(self)
+      ensure
+        @in_transaction = false
+      end
+
+      def exec_in_transaction(sql, args)
+        case sql
+        when /DELETE FROM task WHERE id = \$1/
+          nil
+        when /SELECT schedule FROM plan WHERE id = \$1 AND part = \$2/
+          [{ 'schedule' => '01-01-2001' }]
+        when /UPDATE plan SET schedule = \$3 WHERE id = \$1 AND part = \$2/
+          @updated = args
+          nil
+        else
+          raise "Unexpected transaction SQL: #{sql}"
+        end
+      end
+
+      def outer_exec(sql)
+        case sql
+        when /SELECT project\.\* FROM project/
+          [{ 'login' => 'jeff' }]
+        when /SELECT plan\.\* FROM plan JOIN task/
+          [{ 'id' => '7', 'part' => '11', 'project' => '13' }]
+        else
+          raise "Unexpected outer SQL: #{sql}"
+        end
+      end
+    end.new
+    tasks = Rsk::Tasks.new(pgsql, 'jeff')
+    tasks.postpone(5, 0)
+    assert_equal(['7', '11'], pgsql.updated[0..1])
+    assert_match(/^\d{2}-\d{2}-\d{4}$/, pgsql.updated[2])
+  end
 end


### PR DESCRIPTION
## What was done

Fixed `Tasks#postpone` so it no longer uses the outer pooled connection while already inside a transaction.

## Why

Previously, `Tasks#postpone` deleted the task inside a transaction and then read and updated the plan schedule through the outer pool. That could check out a second connection and break the transaction boundary.

## Changes

- read the plan schedule through the active transaction handle
- update the plan schedule through the same transaction handle
- added a regression test that verifies `postpone` does not reuse the outer pool while the transaction is active
- made the regression test less Ruby-version-sensitive for CI stability

## Verification

- `ruby -c objects/tasks.rb`
- `ruby -c test/test_tasks.rb`
