### PR TITLE
#395: Keep postpone queries on one transaction connection

### DIFF
--- a/objects/plan.rb
+++ b/objects/plan.rb
@@ -33,15 +33,15 @@ class Rsk::Plan
     end
   end
 
-  def schedule
-    @pgsql.exec('SELECT schedule FROM plan WHERE id = $1 AND part = $2', [@id, @part])[0]['schedule']
+  def schedule(con: nil)
+    (con || @pgsql).exec('SELECT schedule FROM plan WHERE id = $1 AND part = $2', [@id, @part])[0]['schedule']
   end
 
-  def reschedule(text)
+  def reschedule(text, con: nil)
     unless /^(daily|weekly|biweekly|monthly|quarterly|annually|\d{2}-\d{2}-\d{4})$/.match?(text)
       raise(Rsk::Urror, "Schedule can either be a word or a date DD-MM-YYYY: #{text.inspect}")
     end
-    @pgsql.exec('UPDATE plan SET schedule = $3 WHERE id = $1 AND part = $2', [@id, @part, text])
+    (con || @pgsql).exec('UPDATE plan SET schedule = $3 WHERE id = $1 AND part = $2', [@id, @part, text])
   end
 
   private

--- a/objects/tasks.rb
+++ b/objects/tasks.rb
@@ -36,8 +36,8 @@ class Rsk::Tasks
     @pgsql.transaction do |t|
       t.exec('DELETE FROM task WHERE id = $1', [id])
       plan = Rsk::Plans.new(@pgsql, Integer(row['project'] || 0)).get(Integer(row['id']), Integer(row['part']))
-      raise(Rsk::Urror, "Can't postpone plan ##{row['id']}") if /^[a-z]+$/.match?(plan.schedule)
-      plan.reschedule((Time.now + seconds).strftime('%d-%m-%Y'))
+      raise(Rsk::Urror, "Can't postpone plan ##{row['id']}") if /^[a-z]+$/.match?(plan.schedule(con: t))
+      plan.reschedule((Time.now + seconds).strftime('%d-%m-%Y'), con: t)
     end
   end
 

--- a/test/test_tasks.rb
+++ b/test/test_tasks.rb
@@ -52,30 +52,29 @@ class Rsk::TasksTest < TestCase
     tasks.postpone(tasks.fetch[0][:id], 60 * 60)
   end
 
-  def test_postpones_using_transaction_connection
-    queries = []
-    transaction = Object.new
-    transaction.define_singleton_method(:exec) do |query, _params|
-      queries << query
-      query.start_with?('SELECT schedule') ? [{ 'schedule' => '01-01-2026' }] : []
-    end
-    calls = 0
-    active = false
-    pgsql = Object.new
-    pgsql.define_singleton_method(:exec) do |query, _params|
-      raise(RuntimeError, 'Pool connection checked out inside transaction') if active
-      calls += 1
-      Array(query).join.include?('SELECT project.*') ? [{ 'login' => 'tester' }] :
-        [{ 'project' => '1', 'id' => '2', 'part' => '3' }]
-    end
-    pgsql.define_singleton_method(:transaction) do |&block|
-      active = true
-      block.call(transaction)
-    ensure
-      active = false
-    end
-    Rsk::Tasks.new(pgsql, 'tester').postpone(4, 60)
-    assert_equal(2, calls)
-    assert_equal(3, queries.size)
+  def test_postpones_tasks_with_one_connection
+    pgsql = Pgtk::Pool.new(
+      Pgtk::Wire::Yaml.new(File.join(__dir__, '../target/pgsql-config.yml')),
+      max: 1,
+      timeout: 0.1,
+      log: Loog::NULL
+    )
+    pgsql.start!
+    login = "bobbyX#{rand(99_999)}"
+    project = Rsk::Projects.new(pgsql, login).add("test#{rand(99_999)}")
+    eid = Rsk::Effects.new(pgsql, project).add('business will stop')
+    Rsk::Triples.new(pgsql, project).add(
+      Rsk::Causes.new(pgsql, project).add('we have data'),
+      Rsk::Risks.new(pgsql, project).add('we may lose it'), eid
+    )
+    plans = Rsk::Plans.new(pgsql, project)
+    plan = plans.get(plans.add(eid, 'solve it!'), eid)
+    schedule = (Time.now - (5 * 24 * 60 * 60)).strftime('%d-%m-%Y')
+    plan.reschedule(schedule)
+    tasks = Rsk::Tasks.new(pgsql, login)
+    tasks.create
+    tasks.postpone(tasks.fetch[0][:id], 60 * 60)
+    assert_equal(0, tasks.count)
+    refute_equal(schedule, plan.schedule)
   end
 end

--- a/test/test_tasks.rb
+++ b/test/test_tasks.rb
@@ -51,4 +51,31 @@ class Rsk::TasksTest < TestCase
     tasks.create
     tasks.postpone(tasks.fetch[0][:id], 60 * 60)
   end
+
+  def test_postpones_using_transaction_connection
+    queries = []
+    transaction = Object.new
+    transaction.define_singleton_method(:exec) do |query, _params|
+      queries << query
+      query.start_with?('SELECT schedule') ? [{ 'schedule' => '01-01-2026' }] : []
+    end
+    calls = 0
+    active = false
+    pgsql = Object.new
+    pgsql.define_singleton_method(:exec) do |query, _params|
+      raise(RuntimeError, 'Pool connection checked out inside transaction') if active
+      calls += 1
+      Array(query).join.include?('SELECT project.*') ? [{ 'login' => 'tester' }] :
+        [{ 'project' => '1', 'id' => '2', 'part' => '3' }]
+    end
+    pgsql.define_singleton_method(:transaction) do |&block|
+      active = true
+      block.call(transaction)
+    ensure
+      active = false
+    end
+    Rsk::Tasks.new(pgsql, 'tester').postpone(4, 60)
+    assert_equal(2, calls)
+    assert_equal(3, queries.size)
+  end
 end


### PR DESCRIPTION
Closes #395.

## Summary

Fixes `Tasks#postpone` checking out an additional pooled database connection while already inside a transaction.

## Changes

- Added an optional `con:` parameter to `Plan#schedule`
- Added an optional `con:` parameter to `Plan#reschedule`
- Passed the active transaction connection from `Tasks#postpone`
- Added a regression test that prevents SQL calls through the pool while the transaction is active

This keeps the task deletion and plan rescheduling atomic and prevents connection pool exhaustion.

## Testing

- `Plan` and `Tasks` tests: 11 tests, 15 assertions, 0 failures
- RuboCop: no offenses