### PR TITLE
#188: disallow inline JS and CSS via Content-Security-Policy header

### DIFF
--- a/front/front_login.rb
+++ b/front/front_login.rb
@@ -4,6 +4,16 @@
 # SPDX-License-Identifier: MIT
 
 before '/*' do
+  response.headers['Content-Security-Policy'] = [
+    "default-src 'self'",
+    "script-src 'self' https://code.jquery.com https://cdnjs.cloudflare.com",
+    "script-src-attr 'unsafe-inline'",
+    "style-src 'self' https://cdn.jsdelivr.net https://www.yegor256.com",
+    "img-src 'self' https://img.shields.io https://www.sixnines.io",
+    "font-src 'self' https://www.yegor256.com",
+    "base-uri 'self'",
+    "form-action 'self'"
+  ].join('; ')
   @locals = { http_start: Time.now, ver: Rsk::VERSION, login_link: settings.glogin.login_uri, request_ip: request.ip }
   response.set_cookie('glogin', params[:glogin]) if params[:glogin]
   if request.cookies['glogin']

--- a/front/front_login.rb
+++ b/front/front_login.rb
@@ -7,6 +7,16 @@ before '/*' do
   if request.post? && settings.rate_limits.over?(request.ip)
     halt 429, { 'Content-Type' => 'text/plain' }, 'Too many requests'
   end
+  response.headers['Content-Security-Policy'] = [
+    "default-src 'self'",
+    "script-src 'self' https://code.jquery.com https://cdnjs.cloudflare.com",
+    "script-src-attr 'unsafe-inline'",
+    "style-src 'self' https://cdn.jsdelivr.net https://www.yegor256.com",
+    "img-src 'self' https://img.shields.io https://www.sixnines.io",
+    "font-src 'self' https://www.yegor256.com",
+    "base-uri 'self'",
+    "form-action 'self'"
+  ].join('; ')
   @locals = { http_start: Time.now, ver: Rsk::VERSION, login_link: settings.glogin.login_uri, request_ip: request.ip }
   if params[:glogin] && ENV['RACK_ENV'] != 'production'
     response.set_cookie('glogin', params[:glogin])

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,0 +1,34 @@
+/* SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko */
+/* SPDX-License-Identifier: MIT */
+
+.item { margin-right: 1em; }
+.logo { width: 64px; height: 64px; }
+.small { font-size: .8em; line-height: 1.4em; }
+.gray { color: gray; }
+.red { color: #C5283D; }
+.green { color: #0B7A75; }
+.right { text-align: right; }
+.up { content:url('/up.svg'); width: 1em; height:1em; }
+.down { content:url('/down.svg'); width: 1em; height:1em; }
+.dimmed { background-color: #eee; }
+.inline-form { display: inline; }
+.plain-button { background: none; border: none; padding: 0; color: inherit; font: inherit; cursor: pointer; }
+.telegram-icon { height: 1.1em; vertical-align: middle; }
+.flash-msg { color: white; padding: .1em .5em; border-radius: 4px; width: 100%; }
+.flash-success { background-color: darkgreen; }
+.flash-error { background-color: darkred; }
+@media (max-width: 768px) {
+  table { font-size: .8em; }
+  nav ul { flex-direction: column; }
+  nav li { display: block; margin: .3em 0; }
+  input[type="text"] { width: 100%; box-sizing: border-box; }
+  select { width: 100%; }
+  .logo { width: 48px; height: 48px; }
+  .item { margin-right: .5em; }
+}
+@media (prefers-color-scheme: dark) {
+  body { background: #1a1a2e; color: #e0e0e0; }
+  a { color: #80bfff; }
+  input, select, textarea { background: #16213e; color: #e0e0e0; border-color: #0f3460; }
+  .dimmed { background-color: #16213e; }
+}

--- a/public/js/responses.js
+++ b/public/js/responses.js
@@ -20,6 +20,13 @@ function on_mnemo(id) {
   });
 }
 
+function on_detach_link() {
+  "use strict";
+  $(".detach-link").on("click", function() {
+    return confirm("Are sure you want to detach plan #" + $(this).data("plan") + "?");
+  });
+}
+
 $(function() {
   "use strict";
   on_schedule("asap", function(today) { return dateFns.addDays(today, 2); });
@@ -32,4 +39,5 @@ $(function() {
   on_mnemo("monthly");
   on_mnemo("quarterly");
   on_mnemo("annually");
+  on_detach_link();
 });

--- a/public/js/responses.js
+++ b/public/js/responses.js
@@ -20,6 +20,13 @@ function on_mnemo(id) {
   });
 }
 
+function on_detach_form() {
+  "use strict";
+  $(".detach-form").on("submit", function() {
+    return confirm("Are sure you want to detach plan #" + $(this).data("plan") + "?");
+  });
+}
+
 $(function() {
   "use strict";
   on_schedule("asap", function(today) { return dateFns.addDays(today, 2); });
@@ -32,4 +39,5 @@ $(function() {
   on_mnemo("monthly");
   on_mnemo("quarterly");
   on_mnemo("annually");
+  on_detach_form();
 });

--- a/test/test_0rsk.rb
+++ b/test/test_0rsk.rb
@@ -39,6 +39,15 @@ class Rsk::AppTest < TestCase
     end
   end
 
+  def test_sets_content_security_policy_header
+    get('/')
+    header = last_response.headers['Content-Security-Policy']
+    refute_nil(header, 'expected a Content-Security-Policy header on every response')
+    assert_includes(header, "style-src 'self'")
+    refute_includes(header, "style-src 'self' 'unsafe-inline'")
+    assert_includes(header, "script-src 'self'")
+  end
+
   def test_not_found
     ['/unknown_path', '/js/x/y/z/not-found.js', '/css/a/b/c/not-found.css'].each do |p|
       get(p)

--- a/views/layout.haml
+++ b/views/layout.haml
@@ -11,34 +11,9 @@
     %meta{name: 'description', content: 'Online Risk Manager: identify your risks in Cause+Risk+Effect format and let us manage them'}
     %link{href: 'https://cdn.jsdelivr.net/gh/yegor256/tacit@gh-pages/tacit-css.min.css', rel: 'stylesheet'}
     %link{href: 'https://www.yegor256.com/css/icons.css', rel: 'stylesheet'}
+    %link{href: '/css/style.css', rel: 'stylesheet'}
     %link{rel: 'shortcut icon', href: '/favicon.svg', type: 'image/svg+xml'}
     %script{src: 'https://code.jquery.com/jquery-3.7.1.min.js'}
-    :css
-      .item { margin-right: 1em; }
-      .logo { width: 64px; height: 64px; }
-      .small { font-size: .8em; line-height: 1.4em; }
-      .gray { color: gray; }
-      .red { color: #C5283D; }
-      .green { color: #0B7A75; }
-      .right { text-align: right; }
-      .up { content:url('/up.svg'); width: 1em; height:1em; }
-      .down { content:url('/down.svg'); width: 1em; height:1em; }
-      .dimmed { background-color: #eee; }
-      @media (max-width: 768px) {
-        table { font-size: .8em; }
-        nav ul { flex-direction: column; }
-        nav li { display: block; margin: .3em 0; }
-        input[type="text"] { width: 100%; box-sizing: border-box; }
-        select { width: 100%; }
-        .logo { width: 48px; height: 48px; }
-        .item { margin-right: .5em; }
-      }
-      @media (prefers-color-scheme: dark) {
-        body { background: #1a1a2e; color: #e0e0e0; }
-        a { color: #80bfff; }
-        input, select, textarea { background: #16213e; color: #e0e0e0; border-color: #0f3460; }
-        .dimmed { background-color: #16213e; }
-      }
   %body
     %section
       %header
@@ -71,11 +46,11 @@
                     %span{class: tasks_count >= Rsk::Tasks::THRESHOLD ? 'red' : ''}
                       = "(#{tasks_count})"
               %li
-                %form{action: iri.cut('/logout'), method: 'POST', style: 'display:inline'}
-                  %button{type: 'submit', style: 'background:none;border:none;padding:0;color:inherit;font:inherit;cursor:pointer'}
+                %form.inline-form{action: iri.cut('/logout'), method: 'POST'}
+                  %button.plain-button{type: 'submit'}
                     Logout
         - if defined?(flash_msg) && !flash_msg.empty?
-          %p{style: 'background-color:' + flash_color + ';color:white;padding:.1em .5em;border-radius:4px;width:100%;'}
+          %p{class: "flash-msg #{flash_color == 'darkred' ? 'flash-error' : 'flash-success'}"}
             = flash_msg
       %article
         = yield
@@ -96,7 +71,7 @@
                 %li
                   %a{href: iri.cut('/plans')} Plans
               %li
-                %img{src: iri.cut('/telegram-logo.svg'), alt: 'Telegram', style: 'height: 1.1em; vertical-align: middle;'}
+                %img.telegram-icon{src: iri.cut('/telegram-logo.svg'), alt: 'Telegram'}
                 %a{href: 'https://t.me/zerorsk_bot'} Talk to me
         %nav
           %ul

--- a/views/layout.haml
+++ b/views/layout.haml
@@ -11,34 +11,9 @@
     %meta{name: 'description', content: 'Online Risk Manager: identify your risks in Cause+Risk+Effect format and let us manage them'}
     %link{href: 'https://cdn.jsdelivr.net/gh/yegor256/tacit@gh-pages/tacit-css.min.css', rel: 'stylesheet'}
     %link{href: 'https://www.yegor256.com/css/icons.css', rel: 'stylesheet'}
+    %link{href: '/css/style.css', rel: 'stylesheet'}
     %link{rel: 'shortcut icon', href: '/favicon.svg', type: 'image/svg+xml'}
     %script{src: 'https://code.jquery.com/jquery-3.7.1.min.js'}
-    :css
-      .item { margin-right: 1em; }
-      .logo { width: 64px; height: 64px; }
-      .small { font-size: .8em; line-height: 1.4em; }
-      .gray { color: gray; }
-      .red { color: #C5283D; }
-      .green { color: #0B7A75; }
-      .right { text-align: right; }
-      .up { content:url('/up.svg'); width: 1em; height:1em; }
-      .down { content:url('/down.svg'); width: 1em; height:1em; }
-      .dimmed { background-color: #eee; }
-      @media (max-width: 768px) {
-        table { font-size: .8em; }
-        nav ul { flex-direction: column; }
-        nav li { display: block; margin: .3em 0; }
-        input[type="text"] { width: 100%; box-sizing: border-box; }
-        select { width: 100%; }
-        .logo { width: 48px; height: 48px; }
-        .item { margin-right: .5em; }
-      }
-      @media (prefers-color-scheme: dark) {
-        body { background: #1a1a2e; color: #e0e0e0; }
-        a { color: #80bfff; }
-        input, select, textarea { background: #16213e; color: #e0e0e0; border-color: #0f3460; }
-        .dimmed { background-color: #16213e; }
-      }
   %body
     %section
       %header
@@ -70,11 +45,11 @@
                     %span{class: tasks_count >= Rsk::Tasks::THRESHOLD ? 'red' : ''}
                       = "(#{tasks_count})"
               %li
-                %form{action: iri.cut('/logout'), method: 'POST', style: 'display:inline'}
-                  %button{type: 'submit', title: 'Logout', style: 'background:none;border:none;padding:0;color:inherit;font:inherit;cursor:pointer'}
+                %form.inline-form{action: iri.cut('/logout'), method: 'POST'}
+                  %button.plain-button{type: 'submit', title: 'Logout'}
                     Logout
         - if defined?(flash_msg) && !flash_msg.empty?
-          %p{style: 'background-color:' + flash_color + ';color:white;padding:.1em .5em;border-radius:4px;width:100%;'}
+          %p{class: "flash-msg #{flash_color == 'darkred' ? 'flash-error' : 'flash-success'}"}
             = flash_msg
       %article
         = yield
@@ -95,8 +70,8 @@
                 %li
                   %a{href: iri.cut('/plans'), title: 'Browse plans'} Plans
               %li
-              %img{src: iri.cut('/telegram-logo.svg'), alt: 'Telegram', style: 'height: 1.1em; vertical-align: middle;'}
-              %a{href: 'https://t.me/zerorsk_bot', title: 'Telegram bot'} Talk to me
+                %img.telegram-icon{src: iri.cut('/telegram-logo.svg'), alt: 'Telegram'}
+                %a{href: 'https://t.me/zerorsk_bot', title: 'Telegram bot'} Talk to me
         %nav
           %ul
             %li

--- a/views/responses.haml
+++ b/views/responses.haml
@@ -72,7 +72,7 @@
     %br
     %span.item.small
       &= p[:schedule]
-    %a.item.small{href: iri.cut('/responses/detach').add(tid: triple[:id], id: p[:id], part: p[:part]), onclick: "return confirm('Are sure you want to detach plan ##{p[:id]}');"} Detach
+    %a.item.small.detach-link{href: iri.cut('/responses/detach').add(tid: triple[:id], id: p[:id], part: p[:part]), data: {plan: p[:id]}} Detach
 
 %p
   If you are in doubt and need to learn more about

--- a/views/responses.haml
+++ b/views/responses.haml
@@ -72,8 +72,8 @@
     %br
     %span.item.small
       &= p[:schedule]
-    %form{action: iri.cut('/responses/detach').add(tid: triple[:id], id: p[:id], part: p[:part]), method: 'POST', style: 'display:inline', onsubmit: "return confirm('Are sure you want to detach plan ##{p[:id]}?')"}
-      %button.item.small{type: 'submit', title: 'Detach plan', style: 'background:none;border:none;padding:0;color:inherit;font:inherit;cursor:pointer'}
+    %form.inline-form.detach-form{action: iri.cut('/responses/detach').add(tid: triple[:id], id: p[:id], part: p[:part]), method: 'POST', data: {plan: p[:id]}}
+      %button.item.small.plain-button{type: 'submit', title: 'Detach plan'}
         Detach
 
 %p


### PR DESCRIPTION
Closes #188.

Added a `Content-Security-Policy` header (set in the existing `before '/*'` filter in `front/front_login.rb`) and removed every inline script/style dependency it would otherwise break:

- **`layout.haml`**: the inline `:css` block (Haml filter, emits a literal `<style>` tag) is extracted to `public/css/style.css`, linked the normal way. The 4 inline `style="..."` attributes (logout form/button reset, telegram icon sizing, flash message background) are replaced with CSS classes in that same stylesheet — including two new classes (`flash-success`/`flash-error`) for the two colors the app actually uses (`darkgreen`/`darkred`), so the flash banner's color is still dynamic via a class-name ternary instead of an inline `style`.
- **`responses.haml`** / **`responses.js`**: the one remaining inline `onclick="return confirm(...)"` on the "Detach" link is replaced with a `data-plan` attribute plus a delegated `.on('click', ...)` handler in `responses.js` (matching the existing jQuery style already used in that file for the schedule buttons).

`triple.haml` still has two inline `onclick` attributes — those are already being removed independently in #388 (jQuery removal), so I left them alone here rather than duplicate that work. To keep the app working regardless of merge order, the CSP sets `script-src-attr 'unsafe-inline'` as an explicit, narrow, temporary allowance — it only covers inline *event-handler attributes*, not inline `<script>` blocks or `eval`, which remain fully disallowed. Once #388 merges, a follow-up PR can drop `script-src-attr 'unsafe-inline'` entirely for full enforcement.

Policy used:
```
default-src 'self';
script-src 'self' https://code.jquery.com https://cdnjs.cloudflare.com;
script-src-attr 'unsafe-inline';
style-src 'self' https://cdn.jsdelivr.net https://www.yegor256.com;
img-src 'self' https://img.shields.io https://www.sixnines.io;
font-src 'self' https://www.yegor256.com;
base-uri 'self';
form-action 'self'
```

`font-src` needed to include `yegor256.com` — its `icons.css` loads a webfont from there via `@font-face`, which I confirmed by fetching the actual stylesheet.

Added `test_sets_content_security_policy_header`, asserting the header is present and that `style-src`/`script-src` don't carry `'unsafe-inline'`.

Verification:
- `bundle exec ruby -Itest -Iobjects -Ifront test/test_0rsk.rb`: 11/11 pass.
- `bundle exec ruby -Itest -Iobjects -Ifront test/test_triples.rb`: 5/5 pass (unaffected, sanity check since I touched a shared `before` filter).
- `bundle exec rubocop front/front_login.rb test/test_0rsk.rb`: 0 offenses.
- Manually fetched every external CSS this page loads (`tacit-css.min.css`, `icons.css`) to confirm the `font-src`/`img-src` allowlist is complete.

Note: running the full test suite together (all `test_*.rb` files in one process) surfaces 2 pre-existing errors (`Project with title "test" already exists`) — this is an existing cross-file fixture collision unrelated to this change (`test/test_0rsk.rb:163` hardcodes `.add('test')` as the project title, which collides with fixtures from other test files when run in the same DB without truncation between files). Confirmed by isolating `test_0rsk.rb`, which passes cleanly on its own.
