### PR TITLE
fix(#398): ignore duplicate task creation races

### DIFF
--- a/objects/tasks.rb
+++ b/objects/tasks.rb
@@ -19,7 +19,7 @@ class Rsk::Tasks
   def create
     Rsk::Pipeline.new(@pgsql, @login).fetch.each do |p|
       next if count >= THRESHOLD
-      @pgsql.exec('INSERT INTO task (plan) VALUES ($1)', [p])
+      @pgsql.exec('INSERT INTO task (plan) VALUES ($1) ON CONFLICT (plan) DO NOTHING', [p])
     end
   end
 

--- a/test/test_tasks.rb
+++ b/test/test_tasks.rb
@@ -68,7 +68,7 @@ class Rsk::TasksTest < TestCase
     tasks = Rsk::Tasks.new(test_pgsql, login)
     pipeline = Object.new
     pipeline.define_singleton_method(:fetch) { [pid] }
-    Rsk::Pipeline.stub(:new, pipeline) { tasks.create }
+    Rsk::Pipeline.stub(:new, ->(*_) { pipeline }) { tasks.create }
     assert_equal(1, Integer(test_pgsql.exec('SELECT COUNT(*) AS c FROM task WHERE plan = $1', [pid])[0]['c']))
   end
 end

--- a/test/test_tasks.rb
+++ b/test/test_tasks.rb
@@ -51,4 +51,24 @@ class Rsk::TasksTest < TestCase
     tasks.create
     tasks.postpone(tasks.fetch[0][:id], 60 * 60)
   end
+
+  def test_ignores_duplicate_plan_insertions
+    login = "bobbyD#{rand(99_999)}"
+    project = Rsk::Projects.new(test_pgsql, login).add("test#{rand(99_999)}")
+    eid = Rsk::Effects.new(test_pgsql, project).add('business will stop')
+    Rsk::Triples.new(test_pgsql, project).add(
+      Rsk::Causes.new(test_pgsql, project).add('we have data'),
+      Rsk::Risks.new(test_pgsql, project).add('we may lose it'),
+      eid
+    )
+    plans = Rsk::Plans.new(test_pgsql, project)
+    pid = plans.add(eid, 'solve it!')
+    plans.get(pid, eid).reschedule((Time.now - (5 * 24 * 60 * 60)).strftime('%d-%m-%Y'))
+    test_pgsql.exec('INSERT INTO task (plan) VALUES ($1)', [pid])
+    tasks = Rsk::Tasks.new(test_pgsql, login)
+    pipeline = Object.new
+    pipeline.define_singleton_method(:fetch) { [pid] }
+    Rsk::Pipeline.stub(:new, pipeline) { tasks.create }
+    assert_equal(1, Integer(test_pgsql.exec('SELECT COUNT(*) AS c FROM task WHERE plan = $1', [pid])[0]['c']))
+  end
 end

--- a/test/test_tasks.rb
+++ b/test/test_tasks.rb
@@ -64,9 +64,13 @@ class Rsk::TasksTest < TestCase
     plans = Rsk::Plans.new(test_pgsql, project)
     pid = plans.add(eid, 'solve it!')
     plans.get(pid, eid).reschedule((Time.now - (5 * 24 * 60 * 60)).strftime('%d-%m-%Y'))
-    test_pgsql.exec('INSERT INTO task (plan) VALUES ($1)', [pid])
     tasks = Rsk::Tasks.new(test_pgsql, login)
-    tasks.create
+    pipeline = Object.new
+    pipeline.define_singleton_method(:fetch) { [pid] }
+    Rsk::Pipeline.stub(:new, pipeline) do
+      test_pgsql.exec('INSERT INTO task (plan) VALUES ($1)', [pid])
+      tasks.create
+    end
     assert_equal(1, Integer(test_pgsql.exec('SELECT COUNT(*) AS c FROM task WHERE plan = $1', [pid])[0]['c']))
   end
 end

--- a/test/test_tasks.rb
+++ b/test/test_tasks.rb
@@ -66,9 +66,7 @@ class Rsk::TasksTest < TestCase
     plans.get(pid, eid).reschedule((Time.now - (5 * 24 * 60 * 60)).strftime('%d-%m-%Y'))
     test_pgsql.exec('INSERT INTO task (plan) VALUES ($1)', [pid])
     tasks = Rsk::Tasks.new(test_pgsql, login)
-    pipeline = Object.new
-    pipeline.define_singleton_method(:fetch) { [pid] }
-    Rsk::Pipeline.stub(:new, ->(*_) { pipeline }) { tasks.create }
+    tasks.create
     assert_equal(1, Integer(test_pgsql.exec('SELECT COUNT(*) AS c FROM task WHERE plan = $1', [pid])[0]['c']))
   end
 end


### PR DESCRIPTION
This closes #398.

In `Tasks#create`, concurrent attempts to create the same task may hit the unique index on `task.plan` and fail with `PG::UniqueViolation`.

I changed the insertion strategy to make it idempotent:

- use `ON CONFLICT (plan) DO NOTHING`
- add a regression test that pre-creates the task row and verifies that `create` doesn't insert a duplicate

This way, concurrent creators don't break the workflow and the existing task remains intact.