### PR TITLE
fix(#205): assert project deletion in test

### DIFF
--- a/test/test_projects.rb
+++ b/test/test_projects.rb
@@ -20,13 +20,13 @@ class Rsk::ProjectsTest < TestCase
 
   def test_deletes_with_triple
     projects = Rsk::Projects.new(test_pgsql, 'jeff094')
-    project_id = projects.add("testfs#{rand(99_999)}")
-    Rsk::Triples.new(test_pgsql, project_id).add(
-      Rsk::Causes.new(test_pgsql, project_id).add('we have data'),
-      Rsk::Risks.new(test_pgsql, project_id).add('we may lose it'),
-      Rsk::Effects.new(test_pgsql, project_id).add('business will stop NOW')
+    pid = projects.add("testfs#{rand(99_999)}")
+    Rsk::Triples.new(test_pgsql, pid).add(
+      Rsk::Causes.new(test_pgsql, pid).add('we have data'),
+      Rsk::Risks.new(test_pgsql, pid).add('we may lose it'),
+      Rsk::Effects.new(test_pgsql, pid).add('business will stop NOW')
     )
-    projects.delete(project_id)
-    assert_empty(test_pgsql.exec('SELECT id FROM project WHERE id = $1', [project_id]).to_a)
+    projects.delete(pid)
+    assert_empty(test_pgsql.exec('SELECT id FROM project WHERE id = $1', [pid]).to_a)
   end
 end

--- a/test/test_projects.rb
+++ b/test/test_projects.rb
@@ -20,12 +20,13 @@ class Rsk::ProjectsTest < TestCase
 
   def test_deletes_with_triple
     projects = Rsk::Projects.new(test_pgsql, 'jeff094')
-    project = projects.add("testfs#{rand(99_999)}")
-    Rsk::Triples.new(test_pgsql, project).add(
-      Rsk::Causes.new(test_pgsql, project).add('we have data'),
-      Rsk::Risks.new(test_pgsql, project).add('we may lose it'),
-      Rsk::Effects.new(test_pgsql, project).add('business will stop NOW')
+    project_id = projects.add("testfs#{rand(99_999)}")
+    Rsk::Triples.new(test_pgsql, project_id).add(
+      Rsk::Causes.new(test_pgsql, project_id).add('we have data'),
+      Rsk::Risks.new(test_pgsql, project_id).add('we may lose it'),
+      Rsk::Effects.new(test_pgsql, project_id).add('business will stop NOW')
     )
-    projects.delete(project)
+    projects.delete(project_id)
+    assert_empty(test_pgsql.exec('SELECT id FROM project WHERE id = $1', [project_id]).to_a)
   end
 end


### PR DESCRIPTION
This closes #205.

The `test_deletes_with_triple` test deleted the project but never asserted that the row was gone.

What is changed here:
- rename the misleading `project` variable to `project_id`
- verify directly in the database that the deleted project record is no longer present

This makes the test actually validate the deletion behavior it exercises.