### PR TITLE
fix(#216): improve page status assertion message

### DIFF
--- a/test/test_0rsk.rb
+++ b/test/test_0rsk.rb
@@ -35,7 +35,7 @@ class Rsk::AppTest < TestCase
     pages = ['/version', '/robots.txt', '/', '/js/triple.js', '/js/responses.js', '/terms']
     pages.each do |p|
       get(p)
-      assert_page_response_status(url: p, reason_keyword: :ok)
+      assert_status(url: p, reason_keyword: :ok)
     end
   end
 
@@ -156,7 +156,7 @@ class Rsk::AppTest < TestCase
     pid
   end
 
-  def assert_page_response_status(url:, reason_keyword:)
+  def assert_status(url:, reason_keyword:)
     expected = Rack::Utils.status_code(reason_keyword)
     assert_equal(
       expected,

--- a/test/test_0rsk.rb
+++ b/test/test_0rsk.rb
@@ -35,7 +35,7 @@ class Rsk::AppTest < TestCase
     pages = ['/version', '/robots.txt', '/', '/js/triple.js', '/js/responses.js', '/terms']
     pages.each do |p|
       get(p)
-      assert_predicate(last_response, :ok?, last_response.body)
+      assert_page_response_status(url: p, reason_keyword: :ok)
     end
   end
 
@@ -154,5 +154,14 @@ class Rsk::AppTest < TestCase
     pid = Rsk::Projects.new(test_pgsql, name).add('test')
     set_cookie("0rsk-project=#{pid}")
     pid
+  end
+
+  def assert_page_response_status(url:, reason_keyword:)
+    expected = Rack::Utils.status_code(reason_keyword)
+    assert_equal(
+      expected,
+      last_response.status,
+      "Response status of #{url} expected #{expected} #{reason_keyword}, got #{last_response.status} #{Rack::Utils::HTTP_STATUS_CODES[last_response.status]}"
+    )
   end
 end


### PR DESCRIPTION
This closes #216.

The page-rendering test previously only reported the raw response body when an expected `200 OK` page failed.

What is changed here:
- add an `assert_page_response_status` helper
- include the page URL, expected status, and actual status in the failure message
- use the helper in `test_renders_pages`

This makes CI failures much easier to diagnose without changing the exercised request paths.