### PR TITLE
fix(#218): enhance login test helper

### DIFF
--- a/test/test_0rsk.rb
+++ b/test/test_0rsk.rb
@@ -149,10 +149,12 @@ class Rsk::AppTest < TestCase
 
   private
 
-  def login(name)
+  def login(name = "u#{SecureRandom.hex(8)}")
     set_cookie("glogin=#{name}")
     pid = Rsk::Projects.new(test_pgsql, name).add('test')
     set_cookie("0rsk-project=#{pid}")
     pid
   end
+
+  alias login_with_project login
 end


### PR DESCRIPTION
This closes #218.

The `login` helper in `test/test_0rsk.rb` currently requires a caller-provided name even when the test does not care about the exact login value.

What is changed here:
- make `login` generate a random login by default
- keep returning the created project id
- add `login_with_project` as an explicit alias for the current behavior

This makes tests a bit easier to write while preserving the existing helper contract.