### PR TITLE
#421: extend TestCase so the database helper is in scope

### DIFF
--- a/test/test_query.rb
+++ b/test/test_query.rb
@@ -6,7 +6,7 @@
 require_relative 'test__helper'
 require_relative '../objects/query'
 
-class Rsk::QueryTest < Minitest::Test
+class Rsk::QueryTest < TestCase
   def test_fetch_pagination
     sql = ['SELECT * FROM project WHERE login = $1']
     query = Rsk::Query.new(test_pgsql, sql, ['test'])


### PR DESCRIPTION
`test/test_query.rb` extended `Minitest::Test` while calling `test_pgsql`,
which lives on `TestCase`, so all five of its tests raised `NameError` and the
`test` job was red on `master` and on every pull request. It now extends
`TestCase`, like every other test in the suite.

Closes #421
