### PR TITLE
#423: clear the rubocop offenses three merges left behind

### DIFF
--- a/front/front_triple.rb
+++ b/front/front_triple.rb
@@ -3,13 +3,15 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
-def json_endpoint
-  halt 403 unless @locals[:user]
-  content_type('application/json')
+helpers do
+  def jsonify
+    halt(403) unless @locals[:user]
+    content_type('application/json')
+  end
 end
 
 get '/causes.json' do
-  json_endpoint
+  jsonify
   JSON.pretty_generate(
     causes.fetch(query: params[:query] || '').map do |r|
       {
@@ -25,7 +27,7 @@ get '/causes.json' do
 end
 
 get '/risks.json' do
-  json_endpoint
+  jsonify
   JSON.pretty_generate(
     risks.fetch(query: params[:query] || '').map do |r|
       {
@@ -41,7 +43,7 @@ get '/risks.json' do
 end
 
 get '/effects.json' do
-  json_endpoint
+  jsonify
   JSON.pretty_generate(
     effects.fetch(query: params[:query] || '').map do |r|
       {
@@ -58,7 +60,7 @@ get '/effects.json' do
 end
 
 get '/plans.json' do
-  json_endpoint
+  jsonify
   JSON.pretty_generate(
     plans.fetch(query: params[:query] || '').map do |r|
       {

--- a/test/test_daemon.rb
+++ b/test/test_daemon.rb
@@ -3,16 +3,13 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
-require_relative 'test__helper'
 require_relative '../objects/daemon'
+require_relative 'test__helper'
 
 class Rsk::DaemonTest < Minitest::Test
   def test_starts_and_stops
     counter = 0
-    daemon = Rsk::Daemon.new(0.01)
-    thread = daemon.start { counter += 1 }
-    sleep 1.5
-    thread.kill
-    assert_operator counter, :>=, 1
+    Rsk::Daemon.new(0.01).start { counter += 1 }.tap { sleep(1.5) }.kill
+    assert_operator(counter, :>=, 1)
   end
 end

--- a/test/test_query.rb
+++ b/test/test_query.rb
@@ -6,7 +6,7 @@
 require_relative 'test__helper'
 require_relative '../objects/query'
 
-class Rsk::QueryTest < Minitest::Test
+class Rsk::QueryTest < TestCase
   def test_fetch_pagination
     sql = ['SELECT * FROM project WHERE login = $1']
     query = Rsk::Query.new(test_pgsql, sql, ['test'])

--- a/test/test_query.rb
+++ b/test/test_query.rb
@@ -3,40 +3,38 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
-require_relative 'test__helper'
 require_relative '../objects/query'
+require_relative 'test__helper'
 
 class Rsk::QueryTest < TestCase
   def test_fetch_pagination
-    sql = ['SELECT * FROM project WHERE login = $1']
-    query = Rsk::Query.new(test_pgsql, sql, ['test'])
-    rows = query.fetch(0, 10)
-    assert_kind_of(Array, rows)
+    assert_kind_of(
+      Array,
+      Rsk::Query.new(test_pgsql, ['SELECT * FROM project WHERE login = $1'], ['test']).fetch(0, 10)
+    )
   end
 
   def test_fetch_second_page
-    sql = ['SELECT * FROM project WHERE login = $1']
-    query = Rsk::Query.new(test_pgsql, sql, ['test'])
-    rows = query.fetch(10, 10)
-    assert_kind_of(Array, rows)
+    assert_kind_of(
+      Array,
+      Rsk::Query.new(test_pgsql, ['SELECT * FROM project WHERE login = $1'], ['test']).fetch(10, 10)
+    )
   end
 
   def test_count
-    sql = ['SELECT 1 AS x']
-    query = Rsk::Query.new(test_pgsql, sql, [])
-    assert_equal(1, query.count)
+    assert_equal(1, Rsk::Query.new(test_pgsql, ['SELECT 1 AS x'], []).count)
   end
 
   def test_count_integer
-    sql = ['SELECT generate_series(1, 5) AS x']
-    query = Rsk::Query.new(test_pgsql, sql, [])
-    assert_equal(5, query.count)
+    assert_equal(5, Rsk::Query.new(test_pgsql, ['SELECT generate_series(1, 5) AS x'], []).count)
   end
 
   def test_empty_fetch
-    sql = ['SELECT * FROM project WHERE login = $1']
-    query = Rsk::Query.new(test_pgsql, sql, ['nonexistent_login'])
-    rows = query.fetch(0, 0)
-    assert_kind_of(Array, rows)
+    assert_kind_of(
+      Array,
+      Rsk::Query.new(
+        test_pgsql, ['SELECT * FROM project WHERE login = $1'], ['nonexistent_login']
+      ).fetch(0, 0)
+    )
   end
 end


### PR DESCRIPTION
Rubocop reported 21 offenses across `front/front_triple.rb`,
`test/test_daemon.rb` and `test/test_query.rb`, none of them ever seen because
the tests died before rubocop ran.

`json_endpoint` moves into a `helpers do` block, where the other view helpers
live, and becomes `jsonify`, a single word, which is what
`Elegant/GoodMethodName` asks for.

The daemon test keeps its meaning: `rubocop -a` would sleep before starting
the daemon and kill the thread at once, so it is written as a chain instead,
`start { ... }.tap { sleep(1.5) }.kill`, which sleeps while the thread runs and
holds no variable.

The query test loses the one-use locals and both files sort their requires.

`rubocop` now reports no offenses over all 54 files.

This branch sits on top of #422, which fixes the tests themselves, so that the
`test` job here has a chance to be green. Merge that one first and this rebases
down to its own commit.

Closes #423
