### PR TITLE
#418: read the login from the string key the cookie carries

### DIFF
--- a/views/layout.haml
+++ b/views/layout.haml
@@ -51,7 +51,7 @@
           %ul
             %li
               - if defined?(user)
-                %a{href: '/projects', title: 'Your projects'}= "@#{user[:login]}"
+                %a{href: '/projects', title: 'Your projects'}= "@#{user['login']}"
                 - if request.cookies['0rsk-project']
                   = '/'
                   %a{href: iri.cut('/project').append(pid), title: 'View project'}= "##{pid}"


### PR DESCRIPTION
The header link read `user[:login]`, but the hash comes from `GLogin::Cookie::Closed#to_user` and has string keys only, so the lookup was always `nil` and the link showed a bare `@`. The rest of the app already uses the string key.

Closes #418
