### PR TITLE
#417: refuse a project id that is not a whole number

### DIFF
--- a/objects/projects.rb
+++ b/objects/projects.rb
@@ -37,6 +37,7 @@ class Rsk::Projects
   end
 
   def exists?(pid)
+    return false unless pid.to_s.match?(/\A[0-9]+\z/)
     !@pgsql.exec('SELECT * FROM project WHERE login = $1 AND id = $2', [@login, pid]).empty?
   end
 end

--- a/test/test_projects.rb
+++ b/test/test_projects.rb
@@ -18,6 +18,13 @@ class Rsk::ProjectsTest < TestCase
     refute(projects.exists?(pid))
   end
 
+  def test_refuses_id_that_is_not_a_number
+    projects = Rsk::Projects.new(test_pgsql, 'jeff12')
+    refute(projects.exists?('abc'))
+    refute(projects.exists?(''))
+    refute(projects.exists?('7abc'))
+  end
+
   def test_deletes_with_triple
     projects = Rsk::Projects.new(test_pgsql, 'jeff094')
     pid = projects.add("testfs#{rand(99_999)}")


### PR DESCRIPTION
`Projects#exists?` passed the id straight to Postgres, where `project.id` is `INT`, so a non-numeric value raised `PG::InvalidTextRepresentation`. Since the value lives in the `0rsk-project` cookie, one mistyped URL made every page unreachable, including `/projects` where the cookie could be replaced.

Refusing a non-numeric id in `exists?` covers all of its callers at once: `/projects/select`, `/project/:id`, `/projects/delete` and `Rsk::App#pid`, which already deletes the cookie and redirects when `exists?` is false.

Closes #417
