### PR TITLE
#416: keep the page body as markup, not as escaped text

### DIFF
--- a/0rsk.rb
+++ b/0rsk.rb
@@ -28,7 +28,7 @@ if ENV['RACK_ENV'] != 'test'
 end
 
 configure do
-  set :haml, format: :xhtml
+  set :haml, format: :xhtml, escape_html: false
   config = { 'github' => { 'client_id' => '?', 'client_secret' => '?', 'encryption_secret' => '' }, 'sentry' => '' }
   cfg = File.join(File.dirname(__FILE__), 'config.yml')
   if File.exist?(cfg)

--- a/test/test_0rsk.rb
+++ b/test/test_0rsk.rb
@@ -47,6 +47,14 @@ class Rsk::AppTest < TestCase
     end
   end
 
+  def test_renders_markup_not_escaped_source
+    login('kate')
+    get('/ranked')
+    assert_equal(200, last_response.status, last_response.body)
+    refute_includes(last_response.body, '&lt;form', last_response.body)
+    assert_includes(last_response.body, '<form', last_response.body)
+  end
+
   def test_user_pages
     login('bill')
     pages = [


### PR DESCRIPTION
Haml 5 defaulted to `escape_html: false`, Haml 6 defaults to `true`, and nothing overrode it after the bump in c9a4f53. So `= yield` in `views/layout.haml` emitted the page body as escaped text, and the same happened to the HTML returned by `part()`, `thumb()` and `rank()`.

Setting `escape_html: false` restores the Haml 5 behaviour the views were written for. The added test asserts the markup itself, since the existing tests only check status codes and cannot see the difference.

Closes #416
