### PR TITLE
#263: hand back a part only when it is in the project

### DIFF
--- a/objects/causes.rb
+++ b/objects/causes.rb
@@ -42,10 +42,7 @@ class Rsk::Causes
 
   def get(id)
     require_relative('cause')
-    if @pgsql.exec(
-      'SELECT id FROM part WHERE id = $1 AND project = $2 AND type = $3',
-      [id, @project, 'Cause']
-    ).empty?
+    if @pgsql.exec('SELECT id FROM part WHERE id = $1 AND project = $2 AND type = $3', [id, @project, 'Cause']).empty?
       raise(Rsk::Urror, "Cause ##{id} is not in project ##{@project}")
     end
     Rsk::Cause.new(@pgsql, id)

--- a/objects/causes.rb
+++ b/objects/causes.rb
@@ -6,6 +6,7 @@ require_relative 'query'
 # SPDX-License-Identifier: MIT
 
 require_relative 'rsk'
+require_relative 'urror'
 
 class Rsk::Causes
   def initialize(pgsql, project)
@@ -41,6 +42,12 @@ class Rsk::Causes
 
   def get(id)
     require_relative('cause')
+    if @pgsql.exec(
+      'SELECT id FROM part WHERE id = $1 AND project = $2 AND type = $3',
+      [id, @project, 'Cause']
+    ).empty?
+      raise(Rsk::Urror, "Cause ##{id} is not in project ##{@project}")
+    end
     Rsk::Cause.new(@pgsql, id)
   end
 

--- a/objects/effects.rb
+++ b/objects/effects.rb
@@ -6,6 +6,7 @@ require_relative 'query'
 # SPDX-License-Identifier: MIT
 
 require_relative 'rsk'
+require_relative 'urror'
 
 class Rsk::Effects
   def initialize(pgsql, project)
@@ -28,6 +29,12 @@ class Rsk::Effects
 
   def get(id)
     require_relative('effect')
+    if @pgsql.exec(
+      'SELECT id FROM part WHERE id = $1 AND project = $2 AND type = $3',
+      [id, @project, 'Effect']
+    ).empty?
+      raise(Rsk::Urror, "Effect ##{id} is not in project ##{@project}")
+    end
     Rsk::Effect.new(@pgsql, id)
   end
 

--- a/objects/risks.rb
+++ b/objects/risks.rb
@@ -6,6 +6,7 @@ require_relative 'risk'
 # SPDX-License-Identifier: MIT
 
 require_relative 'rsk'
+require_relative 'urror'
 
 class Rsk::Risks
   def initialize(pgsql, project)
@@ -28,6 +29,12 @@ class Rsk::Risks
 
   def get(id)
     require_relative('risk')
+    if @pgsql.exec(
+      'SELECT id FROM part WHERE id = $1 AND project = $2 AND type = $3',
+      [id, @project, 'Risk']
+    ).empty?
+      raise(Rsk::Urror, "Risk ##{id} is not in project ##{@project}")
+    end
     Rsk::Risk.new(@pgsql, id)
   end
 

--- a/objects/risks.rb
+++ b/objects/risks.rb
@@ -29,10 +29,7 @@ class Rsk::Risks
 
   def get(id)
     require_relative('risk')
-    if @pgsql.exec(
-      'SELECT id FROM part WHERE id = $1 AND project = $2 AND type = $3',
-      [id, @project, 'Risk']
-    ).empty?
+    if @pgsql.exec('SELECT id FROM part WHERE id = $1 AND project = $2 AND type = $3', [id, @project, 'Risk']).empty?
       raise(Rsk::Urror, "Risk ##{id} is not in project ##{@project}")
     end
     Rsk::Risk.new(@pgsql, id)


### PR DESCRIPTION
`Causes#get`, `Risks#get` and `Effects#get` ignored the `@project` they were built with, and none of the setters on `Cause`, `Risk` and `Effect` carry a project predicate. So `POST /triple/save` with a `cid`, `rid` or `eid` from someone else's project overwrote their text, emoji, probability, impact and `positive`.

Scoping `get` closes it for every caller at once, since the object is only handed back when the part is in the project and of the right type. An id from another project now raises `Rsk::Urror` instead of returning a usable object.

Closes #263
