### PR TITLE
#206: say plainly that the cause, risk or effect is already there

### DIFF
--- a/objects/causes.rb
+++ b/objects/causes.rb
@@ -6,6 +6,7 @@ require_relative 'query'
 # SPDX-License-Identifier: MIT
 
 require_relative 'rsk'
+require_relative 'urror'
 
 class Rsk::Causes
   def initialize(pgsql, project)
@@ -24,6 +25,8 @@ class Rsk::Causes
       t.exec('INSERT INTO cause (id) VALUES ($1)', [id])
       id
     end
+  rescue PG::UniqueViolation
+    raise(Rsk::Urror, "Cause \"#{text}\" already exists in this project")
   end
 
   def emojis

--- a/objects/effects.rb
+++ b/objects/effects.rb
@@ -6,6 +6,7 @@ require_relative 'query'
 # SPDX-License-Identifier: MIT
 
 require_relative 'rsk'
+require_relative 'urror'
 
 class Rsk::Effects
   def initialize(pgsql, project)
@@ -24,6 +25,8 @@ class Rsk::Effects
       t.exec('INSERT INTO effect (id) VALUES ($1)', [id])
       id
     end
+  rescue PG::UniqueViolation
+    raise(Rsk::Urror, "Effect \"#{text}\" already exists in this project")
   end
 
   def get(id)

--- a/objects/risks.rb
+++ b/objects/risks.rb
@@ -6,6 +6,7 @@ require_relative 'risk'
 # SPDX-License-Identifier: MIT
 
 require_relative 'rsk'
+require_relative 'urror'
 
 class Rsk::Risks
   def initialize(pgsql, project)
@@ -24,6 +25,8 @@ class Rsk::Risks
       t.exec('INSERT INTO risk (id) VALUES ($1)', [id])
       id
     end
+  rescue PG::UniqueViolation
+    raise(Rsk::Urror, "Risk \"#{text}\" already exists in this project")
   end
 
   def get(id)


### PR DESCRIPTION
Typing text that already exists in the project hit the `part_project_text_key` constraint and the raw `PG::UniqueViolation` reached the error page as a stacktrace. `Projects#add` already rescues the same thing and raises `Rsk::Urror`; `Causes#add`, `Risks#add` and `Effects#add` now do too.

Closes #206
