### PR TITLE
#268: let the destructive routes answer only to POST

### DIFF
--- a/0rsk.rb
+++ b/0rsk.rb
@@ -83,12 +83,6 @@ get '/ranked' do
   )
 end
 
-get '/ranked/delete' do
-  id = params[:id]
-  triples.delete(id)
-  flash('/ranked', "The ranked triple ##{id} deleted")
-end
-
 post '/ranked/delete' do
   id = params[:id]
   triples.delete(id)
@@ -109,12 +103,6 @@ post '/projects/create' do
   title = params[:title]
   pid = projects.add(title)
   flash("/projects/select?id=#{pid}", "A new project ##{pid} selected")
-end
-
-get '/projects/delete' do
-  pid = params[:id]
-  projects.delete(pid)
-  flash('/projects', "The project ##{pid} has been deleted")
 end
 
 post '/projects/delete' do
@@ -163,7 +151,7 @@ post '/responses/add' do
   flash("/responses?id=#{id}", "Thanks, plan ##{pid}/#{part} added to the triple ##{id}")
 end
 
-get '/responses/detach' do
+post '/responses/detach' do
   tid = Integer(params[:tid])
   id = Integer(params[:id])
   part = Integer(params[:part])

--- a/test/test_0rsk.rb
+++ b/test/test_0rsk.rb
@@ -114,7 +114,7 @@ class Rsk::AppTest < TestCase
 
   def test_deletes_ranked
     pid = login("deleter#{rand(99_999)}")
-    get(
+    post(
       "/ranked/delete?id=#{Rsk::Triples.new(test_pgsql, pid).add(
         Rsk::Causes.new(test_pgsql, pid).add('test cause'),
         Rsk::Risks.new(test_pgsql, pid).add('test risk'),
@@ -128,8 +128,16 @@ class Rsk::AppTest < TestCase
     assert_includes(cookie.to_s, 'deleted')
   end
 
+  def test_refuses_to_delete_over_get
+    name = "getter#{rand(99_999)}"
+    pid = login(name)
+    get("/projects/delete?id=#{pid}")
+    assert_equal(404, last_response.status, last_response.body)
+    assert(Rsk::Projects.new(test_pgsql, name).exists?(pid), last_response.body)
+  end
+
   def test_deletes_project
-    get("/projects/delete?id=#{login("deleter#{rand(99_999)}")}")
+    post("/projects/delete?id=#{login("deleter#{rand(99_999)}")}")
     assert_equal(302, last_response.status, last_response.body)
     assert(last_response.location.end_with?('/projects'))
     cookie = last_response.headers['Set-Cookie']

--- a/test/test_0rsk.rb
+++ b/test/test_0rsk.rb
@@ -133,7 +133,7 @@ class Rsk::AppTest < TestCase
     pid = login(name)
     get("/projects/delete?id=#{pid}")
     assert_equal(404, last_response.status, last_response.body)
-    assert_predicate(Rsk::Projects.new(test_pgsql, name), :exists?, pid)
+    assert(Rsk::Projects.new(test_pgsql, name).exists?(pid), 'the project must survive a GET')
   end
 
   def test_deletes_project

--- a/test/test_0rsk.rb
+++ b/test/test_0rsk.rb
@@ -133,7 +133,7 @@ class Rsk::AppTest < TestCase
     pid = login(name)
     get("/projects/delete?id=#{pid}")
     assert_equal(404, last_response.status, last_response.body)
-    assert(Rsk::Projects.new(test_pgsql, name).exists?(pid), last_response.body)
+    assert_predicate(Rsk::Projects.new(test_pgsql, name), :exists?, pid)
   end
 
   def test_deletes_project

--- a/views/responses.haml
+++ b/views/responses.haml
@@ -72,7 +72,9 @@
     %br
     %span.item.small
       &= p[:schedule]
-    %a.item.small{href: iri.cut('/responses/detach').add(tid: triple[:id], id: p[:id], part: p[:part]), title: 'Detach plan', onclick: "return confirm('Are sure you want to detach plan ##{p[:id]}');"} Detach
+    %form{action: iri.cut('/responses/detach').add(tid: triple[:id], id: p[:id], part: p[:part]), method: 'POST', style: 'display:inline', onsubmit: "return confirm('Are sure you want to detach plan ##{p[:id]}?')"}
+      %button.item.small{type: 'submit', title: 'Detach plan', style: 'background:none;border:none;padding:0;color:inherit;font:inherit;cursor:pointer'}
+        Detach
 
 %p
   If you are in doubt and need to learn more about


### PR DESCRIPTION
`/projects/delete` and `/ranked/delete` each had a `get` route that duplicated the `post` one line for line, and `/responses/detach` was `get` only. Sinatra's `Rack::Protection::HttpOrigin` inspects POST, PUT and DELETE, so a destructive GET was not covered and an `<img src="...">` on a hostile page could fire it with the `glogin` cookie attached.

The two `get` duplicates are gone, since both views already submit a POST form, and `/responses/detach` is now `post` with the link in `responses.haml` turned into a one-button form like the other two.

The second half of the report, `Rack::Protection::AuthenticityToken`, needs `enable :sessions` and a token in every form, which is a wider change than this one.

Closes #268
