### PR TITLE
#441: refuse a part that belongs to another project

### DIFF
--- a/objects/plans.rb
+++ b/objects/plans.rb
@@ -15,6 +15,9 @@ class Rsk::Plans
 
   def add(part, text)
     @pgsql.transaction do |t|
+      if t.exec('SELECT id FROM part WHERE id = $1 AND project = $2', [part, @project]).empty?
+        raise(Rsk::Urror, "Part ##{part} must belong to project ##{@project}")
+      end
       id = Integer(
         t.exec(
           'INSERT INTO part (project, text, type) VALUES ($1, $2, $3) RETURNING id',

--- a/test/test_plans.rb
+++ b/test/test_plans.rb
@@ -29,6 +29,19 @@ class Rsk::PlansTest < TestCase
     plans.get(id, rid).complete
   end
 
+  def test_refuses_a_part_of_another_project
+    mine = test_project
+    theirs = test_project
+    alien = test_risk(project: theirs)
+    assert_includes(
+      assert_raises(Rsk::Urror) do
+        Rsk::Plans.new(test_pgsql, mine).add(alien, 'we make backups')
+      end.message,
+      "must belong to project ##{mine}"
+    )
+    assert_equal(0, Rsk::Plans.new(test_pgsql, theirs).count)
+  end
+
   def test_fetch_no_duplicates
     pid = test_project
     cid = test_cause(project: pid)


### PR DESCRIPTION
`Plans#add` created its own part inside the project but inserted the plan against
the caller-supplied part with no check, so a plan could be attached to a part in
somebody else's project. The victim's `Tasks#create` then picked the plan up and
their Telegram got its text, while `Tasks#plan` refused to resolve it, so the task
could never be closed and was re-notified on every cycle.

The part is now checked against the project inside the same transaction, the way
`Triples#add` already does.

Closes #441
