### PR TITLE
#443: refuse a date that is not in the calendar

### DIFF
--- a/objects/plan.rb
+++ b/objects/plan.rb
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
+require 'date'
 require_relative 'rsk'
 require_relative 'urror'
 
@@ -41,6 +42,13 @@ class Rsk::Plan
   def reschedule(text, con: nil)
     unless /^(daily|weekly|biweekly|monthly|quarterly|annually|\d{2}-\d{2}-\d{4})$/.match?(text)
       raise(Rsk::Urror, "Schedule can either be a word or a date DD-MM-YYYY: #{text.inspect}")
+    end
+    if /^\d{2}-\d{2}-\d{4}$/.match?(text)
+      begin
+        Date.strptime(text, '%d-%m-%Y')
+      rescue Date::Error
+        raise(Rsk::Urror, "There is no such date in the calendar: #{text.inspect}")
+      end
     end
     (con || @pgsql).exec('UPDATE plan SET schedule = $3 WHERE id = $1 AND part = $2', [@id, @part, text])
   end

--- a/test/test_plan.rb
+++ b/test/test_plan.rb
@@ -29,6 +29,14 @@ class Rsk::PlanTest < TestCase
     assert_raises(Rsk::Urror) { plan.reschedule('bad') }
   end
 
+  def test_rejects_a_date_that_is_not_in_the_calendar
+    plan = with_plan
+    %w[99-99-9999 31-02-2026 00-01-2026].each do |text|
+      assert_raises(Rsk::Urror, text) { plan.reschedule(text) }
+    end
+    assert_equal('weekly', plan.schedule)
+  end
+
   def test_completes_word_schedule
     plan = with_plan(login: "planW#{SecureRandom.hex(8)}", title: "pw#{SecureRandom.hex(8)}")
     plan.reschedule('daily')


### PR DESCRIPTION
`reschedule` checked the shape of a date, not whether it exists, so `99-99-9999`
was stored and `Pipeline#deadline` later raised on it. That exception leaves the
daemon loop over all users, so every user ordered after the offending row stopped
getting tasks generated, on every cycle.

The date is parsed strictly now, which also catches `31-02-2026`, a date
`Time.parse` silently rolls forward into March.

Closes #443
