### PR TITLE
#448: let a user re-link Telegram from another chat

### DIFF
--- a/objects/telechats.rb
+++ b/objects/telechats.rb
@@ -11,7 +11,13 @@ class Rsk::Telechats
   end
 
   def add(id, login)
-    @pgsql.exec('INSERT INTO telechat (id, login) VALUES ($1, $2)', [id, login])
+    @pgsql.transaction do |t|
+      t.exec('DELETE FROM telechat WHERE login = $1 AND id <> $2', [login, id])
+      t.exec('INSERT INTO telechat (id, login) VALUES ($1, $2) ON CONFLICT (id) DO NOTHING', [id, login])
+      if t.exec('SELECT login FROM telechat WHERE id = $1', [id])[0]['login'] != login
+        raise(Rsk::Urror, "Telegram chat ##{id} is already linked to another account")
+      end
+    end
   end
 
   def exists?(id)

--- a/test/test_telechats.rb
+++ b/test/test_telechats.rb
@@ -40,9 +40,9 @@ class Rsk::TelechatsTest < TestCase
   def test_double_add
     telechats = Rsk::Telechats.new(test_pgsql)
     chat = SecureRandom.random_number(2_000_000_000) + 1
-    telechats.add(chat, "judyDA#{rand(99_999)}")
-    assert_raises(PG::UniqueViolation) do
-      telechats.add(chat, 'other')
+    telechats.add(chat, "judyDA#{SecureRandom.hex(8)}")
+    assert_raises(Rsk::Urror) do
+      telechats.add(chat, "other#{SecureRandom.hex(8)}")
     end
   end
 
@@ -58,6 +58,26 @@ class Rsk::TelechatsTest < TestCase
     login = "judySG#{SecureRandom.hex(8)}"
     telechats = Rsk::Telechats.new(test_pgsql)
     chat = -(1_001_000_000_000 + SecureRandom.random_number(1_000_000_000))
+    telechats.add(chat, login)
+    assert_equal(chat, telechats.chat(login))
+  end
+
+  def test_relinks_from_another_chat
+    login = "judyRL#{SecureRandom.hex(8)}"
+    telechats = Rsk::Telechats.new(test_pgsql)
+    first = SecureRandom.random_number(2_000_000_000) + 1
+    second = SecureRandom.random_number(2_000_000_000) + 1
+    telechats.add(first, login)
+    telechats.add(second, login)
+    assert_equal(second, telechats.chat(login))
+    refute(telechats.exists?(first))
+  end
+
+  def test_adds_the_same_chat_twice
+    login = "judyST#{SecureRandom.hex(8)}"
+    telechats = Rsk::Telechats.new(test_pgsql)
+    chat = SecureRandom.random_number(2_000_000_000) + 1
+    telechats.add(chat, login)
     telechats.add(chat, login)
     assert_equal(chat, telechats.chat(login))
   end


### PR DESCRIPTION
`Telechats#add` was a bare insert, so a user who changed device or clicked the
identify link from a second chat hit the `UNIQUE(login)` constraint and got a 503
page, with no way to re-link.

The old row for that login is dropped first, so re-linking works and linking the
same chat twice is harmless. A chat already linked to somebody else is still
refused, now as an `Rsk::Urror` rather than a raw constraint violation.

Closes #448
