### PR TITLE
#445: widen the telechat identifier to a bigint

### DIFF
--- a/liquibase/2019/015-telechat-bigint.xml
+++ b/liquibase/2019/015-telechat-bigint.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+* SPDX-License-Identifier: MIT
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd" logicalFilePath="001-initial-schema.xml">
+  <changeSet id="015" author="yegor256">
+    <sql>
+      ALTER TABLE teleping ALTER COLUMN telechat TYPE BIGINT;
+      ALTER TABLE telechat ALTER COLUMN id TYPE BIGINT;
+      ALTER TABLE telechat ALTER COLUMN id DROP DEFAULT;
+      DROP SEQUENCE IF EXISTS telechat_id_seq;
+    </sql>
+  </changeSet>
+</databaseChangeLog>

--- a/test/test_telechats.rb
+++ b/test/test_telechats.rb
@@ -45,4 +45,20 @@ class Rsk::TelechatsTest < TestCase
       telechats.add(chat, 'other')
     end
   end
+
+  def test_accepts_a_modern_telegram_chat
+    login = "judyBI#{SecureRandom.hex(8)}"
+    telechats = Rsk::Telechats.new(test_pgsql)
+    chat = 5_000_000_000 + SecureRandom.random_number(1_000_000_000)
+    telechats.add(chat, login)
+    assert_equal(chat, telechats.chat(login))
+  end
+
+  def test_accepts_a_supergroup_chat
+    login = "judySG#{SecureRandom.hex(8)}"
+    telechats = Rsk::Telechats.new(test_pgsql)
+    chat = -(1_001_000_000_000 + SecureRandom.random_number(1_000_000_000))
+    telechats.add(chat, login)
+    assert_equal(chat, telechats.chat(login))
+  end
 end


### PR DESCRIPTION
`telechat.id` was a 32-bit `SERIAL`, but the value always comes from Telegram, and
Telegram identifiers passed 2147483647 years ago; supergroups are `-100...`.
Anyone with such an id got `PG::NumericValueOutOfRange` and a 503 page, and could
never link their account. The suite worked around the ceiling by generating chats
below 2^31.

The column is `BIGINT` now, with the sequence dropped since the value is never
generated, and `teleping.telechat` widened to match.

Closes #445
