### PR TITLE
#444: carry the owning project out of the plan lookup

### DIFF
--- a/objects/tasks.rb
+++ b/objects/tasks.rb
@@ -27,7 +27,7 @@ class Rsk::Tasks
     row = plan(id)
     @pgsql.transaction do |t|
       t.exec('DELETE FROM task WHERE id = $1', [id])
-      Rsk::Plans.new(@pgsql, Integer(row['project'] || 0)).get(Integer(row['id']), Integer(row['part'])).complete
+      Rsk::Plans.new(@pgsql, Integer(row['project'])).get(Integer(row['id']), Integer(row['part'])).complete
     end
   end
 
@@ -35,7 +35,7 @@ class Rsk::Tasks
     row = plan(id)
     @pgsql.transaction do |t|
       t.exec('DELETE FROM task WHERE id = $1', [id])
-      plan = Rsk::Plans.new(@pgsql, Integer(row['project'] || 0)).get(Integer(row['id']), Integer(row['part']))
+      plan = Rsk::Plans.new(@pgsql, Integer(row['project'])).get(Integer(row['id']), Integer(row['part']))
       raise(Rsk::Urror, "Can't postpone plan ##{row['id']}") if /^[a-z]+$/.match?(plan.schedule(con: t))
       plan.reschedule((Time.now + seconds).strftime('%d-%m-%Y'), con: t)
     end
@@ -126,6 +126,6 @@ class Rsk::Tasks
     raise(Rsk::Urror, "Task ##{id} doesn't belong to #{@login}") if project['login'] != @login
     row = @pgsql.exec('SELECT plan.* FROM plan JOIN task ON task.plan = plan.id WHERE task.id = $1', [id])[0]
     raise(Rsk::Urror, "Plan for task ##{id} not found") if row.nil?
-    row
+    row.merge('project' => project['id'])
   end
 end

--- a/test/test_tasks.rb
+++ b/test/test_tasks.rb
@@ -12,6 +12,7 @@ require_relative '../objects/projects'
 require_relative '../objects/risks'
 require_relative '../objects/rsk'
 require_relative '../objects/tasks'
+require 'securerandom'
 require_relative '../objects/triples'
 
 class Rsk::TasksTest < TestCase
@@ -76,5 +77,20 @@ class Rsk::TasksTest < TestCase
     tasks.postpone(tasks.fetch[0][:id], 60 * 60)
     assert_equal(0, tasks.count)
     refute_equal(schedule, plan.schedule)
+  end
+
+  def test_resolves_the_owning_project
+    login = "bobbyP#{SecureRandom.hex(8)}"
+    project = Rsk::Projects.new(test_pgsql, login).add("test#{SecureRandom.hex(8)}")
+    eid = Rsk::Effects.new(test_pgsql, project).add('business will stop')
+    Rsk::Triples.new(test_pgsql, project).add(
+      Rsk::Causes.new(test_pgsql, project).add('we have data'),
+      Rsk::Risks.new(test_pgsql, project).add('we may lose it'), eid
+    )
+    plans = Rsk::Plans.new(test_pgsql, project)
+    plans.get(plans.add(eid, 'solve it!'), eid).reschedule((Time.now - (5 * 24 * 60 * 60)).strftime('%d-%m-%Y'))
+    tasks = Rsk::Tasks.new(test_pgsql, login)
+    tasks.create
+    assert_equal(project, Integer(tasks.__send__(:plan, tasks.fetch[0][:id])['project']))
   end
 end


### PR DESCRIPTION
`Tasks#done` and `Tasks#postpone` read `row['project']` off a `plan` row, and the
`plan` table has no such column, so the value was always nil and `|| 0` built
`Rsk::Plans` with project 0. Nothing breaks today only because `Plans#get` ignores
the project; as soon as it is scoped to the tenant, both routes break for
everyone.

`plan(id)` already fetches the owning project row a few lines above, so it now
carries that id out with the plan row, and the `|| 0` fallback is gone.

Closes #444
