### PR TITLE
#446: clamp the limit the way the offset is clamped

### DIFF
--- a/0rsk.rb
+++ b/0rsk.rb
@@ -20,6 +20,7 @@ require 'telebot'
 require 'time'
 require 'yaml'
 require_relative 'objects/limits'
+require_relative 'objects/paging'
 require_relative 'objects/urror'
 require_relative 'version'
 
@@ -70,8 +71,9 @@ get '/' do
 end
 
 get '/ranked' do
-  offset = [Integer(params[:offset] || '0'), 0].max
-  limit = Integer(params[:limit] || '10')
+  paging = Rsk::Paging.new(params, limit: 10)
+  offset = paging.offset
+  limit = paging.limit
   query = params[:q] || ''
   haml :ranked, layout: :layout, locals: merged(
     title: '/ranked',
@@ -161,8 +163,9 @@ post '/responses/detach' do
 end
 
 get '/causes' do
-  offset = [Integer(params[:offset] || '0'), 0].max
-  limit = Integer(params[:limit] || '25')
+  paging = Rsk::Paging.new(params, limit: 25)
+  offset = paging.offset
+  limit = paging.limit
   query = params[:q] || ''
   haml :causes, layout: :layout, locals: merged(
     title: '/causes',
@@ -176,8 +179,9 @@ get '/causes' do
 end
 
 get '/risks' do
-  offset = [Integer(params[:offset] || '0'), 0].max
-  limit = Integer(params[:limit] || '25')
+  paging = Rsk::Paging.new(params, limit: 25)
+  offset = paging.offset
+  limit = paging.limit
   query = params[:q] || ''
   haml :risks, layout: :layout, locals: merged(
     title: '/risks',
@@ -190,8 +194,9 @@ get '/risks' do
 end
 
 get '/effects' do
-  offset = [Integer(params[:offset] || '0'), 0].max
-  limit = Integer(params[:limit] || '25')
+  paging = Rsk::Paging.new(params, limit: 25)
+  offset = paging.offset
+  limit = paging.limit
   query = params[:q] || ''
   haml :effects, layout: :layout, locals: merged(
     title: '/effects',
@@ -204,8 +209,9 @@ get '/effects' do
 end
 
 get '/plans' do
-  offset = [Integer(params[:offset] || '0'), 0].max
-  limit = Integer(params[:limit] || '25')
+  paging = Rsk::Paging.new(params, limit: 25)
+  offset = paging.offset
+  limit = paging.limit
   query = params[:q] || ''
   haml :plans, layout: :layout, locals: merged(
     title: '/plans',

--- a/front/front_tasks.rb
+++ b/front/front_tasks.rb
@@ -5,6 +5,7 @@ require_relative '../objects/pipeline'
 # SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
+require_relative '../objects/paging'
 require_relative '../objects/postpone'
 require_relative '../objects/tasks'
 
@@ -16,8 +17,9 @@ Rsk::Daemon.new(10).start do
 end
 
 get '/tasks' do
-  offset = [Integer(params[:offset] || '0'), 0].max
-  limit = Integer(params[:limit] || '10')
+  paging = Rsk::Paging.new(params, limit: 10)
+  offset = paging.offset
+  limit = paging.limit
   query = params[:q] || ''
   haml :tasks, layout: :layout, locals: merged(
     title: '/tasks',

--- a/objects/paging.rb
+++ b/objects/paging.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'rsk'
+require_relative 'urror'
+
+class Rsk::Paging
+  MAX = 100
+
+  def initialize(params, limit: 10)
+    @params = params
+    @limit = limit
+  end
+
+  def offset
+    [number(:offset, 0), 0].max
+  end
+
+  def limit
+    number(:limit, @limit).clamp(1, Rsk::Paging::MAX)
+  end
+
+  private
+
+  def number(name, default)
+    text = @params[name]
+    return default if text.nil? || text.to_s.empty?
+    begin
+      Integer(text.to_s, 10)
+    rescue ArgumentError
+      raise(Rsk::Urror, "The #{name} must be a number: #{text.inspect}")
+    end
+  end
+end

--- a/test/test_0rsk.rb
+++ b/test/test_0rsk.rb
@@ -77,6 +77,14 @@ class Rsk::AppTest < TestCase
     end
   end
 
+  def test_survives_a_bad_limit
+    login("limitless#{rand(99_999)}")
+    ['/ranked?limit=-1', '/ranked?limit=99999999', '/causes?limit=0', '/tasks?limit=-3'].each do |p|
+      get(p)
+      assert_equal(200, last_response.status, "#{p} fails: #{last_response.body}")
+    end
+  end
+
   def test_forbids_anonymous_json_pages
     [
       '/causes.json',

--- a/test/test_paging.rb
+++ b/test/test_paging.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'test__helper'
+
+require_relative '../objects/paging'
+require_relative '../objects/urror'
+
+class Rsk::PagingTest < TestCase
+  def test_defaults
+    paging = Rsk::Paging.new({}, limit: 25)
+    assert_equal(0, paging.offset)
+    assert_equal(25, paging.limit)
+  end
+
+  def test_clamps_the_limit
+    assert_equal(1, Rsk::Paging.new({ limit: '-1' }).limit)
+    assert_equal(1, Rsk::Paging.new({ limit: '0' }).limit)
+    assert_equal(Rsk::Paging::MAX, Rsk::Paging.new({ limit: '99999999' }).limit)
+    assert_equal(7, Rsk::Paging.new({ limit: '7' }).limit)
+  end
+
+  def test_clamps_the_offset
+    assert_equal(0, Rsk::Paging.new({ offset: '-5' }).offset)
+    assert_equal(5, Rsk::Paging.new({ offset: '5' }).offset)
+  end
+
+  def test_refuses_a_word
+    assert_raises(Rsk::Urror) { Rsk::Paging.new({ offset: 'abc' }).offset }
+    assert_raises(Rsk::Urror) { Rsk::Paging.new({ limit: 'abc' }).limit }
+  end
+end


### PR DESCRIPTION
All six listing routes clamped the offset and left the limit alone, so
`?limit=-1` reached Postgres and gave a 503 page, and `?limit=99999999` ran the
heavy triples query with no ceiling. A word in either parameter raised
`ArgumentError` and showed a backtrace.

Both numbers now come from one object that clamps them and reports a bad number as
`Rsk::Urror`, which the error handler turns into a flash.

Closes #446
