### PR TITLE
#442: count the requests per client, not globally

### DIFF
--- a/0rsk.rb
+++ b/0rsk.rb
@@ -19,6 +19,7 @@ require 'sinatra'
 require 'telebot'
 require 'time'
 require 'yaml'
+require_relative 'objects/limits'
 require_relative 'objects/urror'
 require_relative 'version'
 
@@ -48,7 +49,7 @@ configure do
   set :config, config
   set :logging, true
   set :log, Loog::REGULAR
-  set :rate_limits, []
+  set :rate_limits, Rsk::Limits.new
   set :server_settings, timeout: 25
   set :glogin, GLogin::Auth.new(
     config['github']['client_id'],

--- a/front/front_login.rb
+++ b/front/front_login.rb
@@ -4,11 +4,8 @@
 # SPDX-License-Identifier: MIT
 
 before '/*' do
-  now = Time.now.to_i
-  settings.rate_limits.reject! { |t| t < now - 60 }
-  if request.post?
-    settings.rate_limits << now
-    halt 429, { 'Content-Type' => 'text/plain' }, 'Too many requests' if settings.rate_limits.size > 10
+  if request.post? && settings.rate_limits.over?(request.ip)
+    halt 429, { 'Content-Type' => 'text/plain' }, 'Too many requests'
   end
   @locals = { http_start: Time.now, ver: Rsk::VERSION, login_link: settings.glogin.login_uri, request_ip: request.ip }
   if params[:glogin] && ENV['RACK_ENV'] != 'production'

--- a/objects/limits.rb
+++ b/objects/limits.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'rsk'
+
+class Rsk::Limits
+  def initialize(max: 10, period: 60)
+    @max = max
+    @period = period
+    @seen = {}
+    @mutex = Mutex.new
+  end
+
+  def over?(client, now: Time.now.to_i)
+    @mutex.synchronize do
+      @seen.each_value { |hits| hits.reject! { |t| t < now - @period } }
+      @seen.reject! { |_, hits| hits.empty? }
+      hits = (@seen[client] ||= [])
+      hits << now
+      hits.size > @max
+    end
+  end
+end

--- a/test/test_limits.rb
+++ b/test/test_limits.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'test__helper'
+
+require_relative '../objects/limits'
+
+class Rsk::LimitsTest < TestCase
+  def test_counts_per_client
+    limits = Rsk::Limits.new(max: 3)
+    3.times { refute(limits.over?('1.1.1.1')) }
+    assert(limits.over?('1.1.1.1'))
+    refute(limits.over?('2.2.2.2'), 'one client must not block another one')
+  end
+
+  def test_forgets_old_hits
+    limits = Rsk::Limits.new(max: 2, period: 60)
+    now = Time.now.to_i
+    2.times { limits.over?('1.1.1.1', now: now) }
+    assert(limits.over?('1.1.1.1', now: now))
+    refute(limits.over?('1.1.1.1', now: now + 61))
+  end
+
+  def test_survives_concurrent_hits
+    limits = Rsk::Limits.new(max: 1_000_000)
+    Array.new(8) do
+      Thread.new { 100.times { limits.over?("ip#{Thread.current.object_id}") } }
+    end.each(&:join)
+    refute(limits.over?('1.1.1.1'))
+  end
+end


### PR DESCRIPTION
The limiter kept one array of timestamps for the whole process, so eleven POSTs a
minute from one client shut writes off for everybody, and the array was mutated
from several request threads with no lock.

The counting moved into an object keyed by the client address and guarded by a
mutex, and it forgets a client once its hits age out.

Closes #442
