### PR TITLE
#447: validate the form instead of showing a backtrace

### DIFF
--- a/front/front_misc.rb
+++ b/front/front_misc.rb
@@ -68,6 +68,12 @@ module Rsk::Misc
     out
   end
 
+  def number(text, name)
+    Integer(text.to_s, 10)
+  rescue ArgumentError
+    raise(Rsk::Urror, "The #{name} must be a number: #{text.inspect}")
+  end
+
   def flash(uri, msg = '', color: 'darkgreen')
     response.set_cookie('flash_msg', msg)
     response.set_cookie('flash_color', color)

--- a/front/front_tasks.rb
+++ b/front/front_tasks.rb
@@ -33,13 +33,13 @@ get '/tasks' do
 end
 
 get '/tasks/done' do
-  id = Integer(params[:id])
+  id = number(params[:id], 'id')
   tasks.done(id)
   flash('/tasks', "Thanks, task ##{id} was completed!")
 end
 
 get '/tasks/later' do
-  id = Integer(params[:id])
+  id = number(params[:id], 'id')
   tasks.postpone(id, Rsk::Postpone.new(params[:period]).seconds)
   flash('/tasks', "Thanks, the task ##{id} was postponed")
 end

--- a/front/front_triple.rb
+++ b/front/front_triple.rb
@@ -87,6 +87,9 @@ get '/triple' do
 end
 
 post '/triple/save' do
+  %i[ctext rtext etext cid rid eid probability impact].each do |name|
+    raise(Rsk::Urror, "The #{name} is missing in the form") if params[name].nil?
+  end
   ctext = params[:ctext].strip
   rtext = params[:rtext].strip
   etext = params[:etext].strip
@@ -97,8 +100,8 @@ post '/triple/save' do
   causes.get(cid).decorate(params[:emoji])
   risks.get(rid).rename(rtext)
   effects.get(eid).rename(etext)
-  risks.get(rid).weigh(Integer(params[:probability]))
-  effects.get(eid).weigh(Integer(params[:impact]))
+  risks.get(rid).weigh(number(params[:probability], 'probability'))
+  effects.get(eid).weigh(number(params[:impact], 'impact'))
   effects.get(eid).polarize(!params[:positive].nil?)
   tid = triples.add(cid, rid, eid)
   flash("/responses?id=#{tid}", "Thanks, the triple ##{tid} successfully saved!")

--- a/objects/effect.rb
+++ b/objects/effect.rb
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: MIT
 
 require_relative 'rsk'
+require_relative 'urror'
 
 class Rsk::Effect
   attr_reader :id
@@ -26,6 +27,7 @@ class Rsk::Effect
   end
 
   def weigh(value)
+    raise(Rsk::Urror, "The impact must be between 1 and 9: #{value.inspect}") unless (1..9).cover?(value)
     @pgsql.exec('UPDATE effect SET impact = $2 WHERE id = $1', [@id, value])
   end
 

--- a/objects/risk.rb
+++ b/objects/risk.rb
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: MIT
 
 require_relative 'rsk'
+require_relative 'urror'
 
 class Rsk::Risk
   attr_reader :id
@@ -26,6 +27,9 @@ class Rsk::Risk
   end
 
   def weigh(value)
+    unless (1..9).cover?(value)
+      raise(Rsk::Urror, "The probability must be between 1 and 9: #{value.inspect}")
+    end
     @pgsql.exec('UPDATE risk SET probability = $2 WHERE id = $1', [@id, value])
   end
 end

--- a/test/test_0rsk.rb
+++ b/test/test_0rsk.rb
@@ -110,6 +110,17 @@ class Rsk::AppTest < TestCase
     assert_equal(200, last_response.status, last_response.body)
   end
 
+  def test_shows_no_backtrace_on_bad_input
+    login("clumsy#{rand(99_999)}")
+    ['probability=100&impact=5', 'probability=abc&impact=5', 'probability=5'].each do |tail|
+      salt = rand(99_999_999)
+      post('/triple/save', "ctext=c#{salt}&rtext=r#{salt}&etext=e#{salt}&emoji=A&cid=&rid=&eid=&#{tail}")
+      refute_includes(last_response.body, '<pre', "#{tail} shows a backtrace: #{last_response.body}")
+    end
+    get('/tasks/done?id=abc')
+    refute_includes(last_response.body, '<pre', last_response.body)
+  end
+
   def test_logout
     login('bob')
     get('/logout')


### PR DESCRIPTION
A probability of 100 reached the database and violated a check constraint, a
missing form field raised `NoMethodError` on nil, and a word where a number was
expected raised `ArgumentError`. None of them is an `Urror`, so each showed
absolute paths, gem versions and the whole call chain in the browser.

The three are validated at the boundary now and raised as `Rsk::Urror`, which the
handler already turns into a flash. `weigh` also refuses a value outside the range
the schema allows, so the constraint cannot be reached from anywhere else either.

Closes #447
