### PR TITLE
#449: escape the user text that goes into Telegram

### DIFF
--- a/front/front_telegram.rb
+++ b/front/front_telegram.rb
@@ -5,8 +5,10 @@
 
 require 'telebot'
 require_relative '../objects/daemon'
+require_relative '../objects/markdown'
 require_relative '../objects/telechats'
 require_relative '../objects/telepings'
+require_relative '../objects/trimmed'
 require_relative '../objects/urror'
 
 get '/telegram' do
@@ -37,7 +39,7 @@ module Rsk::Telegram
       chat_id: chat,
       parse_mode: 'Markdown',
       disable_web_page_preview: true,
-      text: msg.length > 4000 ? "#{msg[0..4000]}..." : msg,
+      text: Rsk::Trimmed.new(msg, 4000).to_s,
       reply_markup: reply_markup
     )
   end
@@ -144,6 +146,7 @@ module Rsk::Telegram
         fresh.each { |t| telepings.add(t[:id], chat) }
       end
     rescue StandardError => e
+      Sentry.capture_exception(e)
       settings.log.error(e.message)
       next
     end
@@ -158,12 +161,13 @@ module Rsk::Telegram
         next if count.zero?
         msg = [
           "You have #{count} risk#{'s' unless count == 1} without response",
-          "plan#{'s' unless count == 1} in project '#{project[:title]}'.",
+          "plan#{'s' unless count == 1} in project '#{Rsk::Markdown.new(project[:title])}'.",
           '[View them](https://www.0rsk.com/ranked?q=%2Balone).'
         ].join(' ')
         telepost(msg, chat) if telechats.diff?(msg, chat)
       end
     rescue StandardError => e
+      Sentry.capture_exception(e)
       settings.log.error(e.message)
       next
     end
@@ -177,10 +181,10 @@ module Rsk::Telegram
           [
             "\n\n[T#{t[:id]}](https://www.0rsk.com/responses?id=#{t[:triple]})",
             "(#{t[:positive] ? '+' : '-'}#{t[:rank]})",
-            t[:text],
-            "in [#{t[:title]}](https://www.0rsk.com/projects/#{t[:pid]}):",
-            "#{t[:ctext]}; #{t[:rtext]}; #{t[:etext]}",
-            "(#{t[:schedule]})"
+            Rsk::Markdown.new(t[:text]).to_s,
+            "in [#{Rsk::Markdown.new(t[:title])}](https://www.0rsk.com/projects/#{t[:pid]}):",
+            "#{Rsk::Markdown.new(t[:ctext])}; #{Rsk::Markdown.new(t[:rtext])}; #{Rsk::Markdown.new(t[:etext])}",
+            "(#{Rsk::Markdown.new(t[:schedule])})"
           ].join(' ')
         end
       ]
@@ -190,15 +194,17 @@ module Rsk::Telegram
         list.map do |t|
           [
             "\n  `T#{t[:id]}` (#{t[:positive] ? '+' : '-'}#{t[:rank]})",
-            t[:text],
-            "#{t[:ctext]}; #{t[:rtext]}; #{t[:etext]}"
+            Rsk::Markdown.new(t[:text]).to_s,
+            "#{Rsk::Markdown.new(t[:ctext])}; #{Rsk::Markdown.new(t[:rtext])}; #{Rsk::Markdown.new(t[:etext])}"
           ].join(' ')
         end
       ]
     else
       [
         "There are too many tasks in the list (#{list.count}), here is the top of it:\n",
-        list.take(16).map! { |t| "\n`T#{t[:id]}` (#{t[:positive] ? '+' : '-'}#{t[:rank]}) #{t[:text]}" }
+        list.take(16).map! do |t|
+          "\n`T#{t[:id]}` (#{t[:positive] ? '+' : '-'}#{t[:rank]}) #{Rsk::Markdown.new(t[:text])}"
+        end
       ]
     end
   end

--- a/objects/markdown.rb
+++ b/objects/markdown.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'rsk'
+
+class Rsk::Markdown
+  SPECIAL = ['\\', '_', '*', '`', '[', ']'].freeze
+
+  def initialize(text)
+    @text = text
+  end
+
+  def to_s
+    @text.to_s.chars.map { |c| Rsk::Markdown::SPECIAL.include?(c) ? "\\#{c}" : c }.join
+  end
+end

--- a/objects/trimmed.rb
+++ b/objects/trimmed.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'rsk'
+
+class Rsk::Trimmed
+  def initialize(text, max)
+    @text = text
+    @max = max
+  end
+
+  def to_s
+    text = @text.to_s
+    return text if text.length <= @max
+    head = text[0...@max]
+    stop = head.rindex("\n")
+    "#{stop.nil? ? head : head[0...stop]}..."
+  end
+end

--- a/test/test_markdown.rb
+++ b/test/test_markdown.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'test__helper'
+
+require_relative '../objects/markdown'
+require_relative '../objects/trimmed'
+
+class Rsk::MarkdownTest < TestCase
+  def test_escapes_the_entities
+    assert_equal('review \\[pending\\] docs', Rsk::Markdown.new('review [pending] docs').to_s)
+    assert_equal('budget\\_2026\\_q1', Rsk::Markdown.new('budget_2026_q1').to_s)
+    assert_equal('a\\*b\\`c', Rsk::Markdown.new('a*b`c').to_s)
+    assert_equal('\\\\', Rsk::Markdown.new('\\').to_s)
+  end
+
+  def test_leaves_plain_text_alone
+    assert_equal('we make backups', Rsk::Markdown.new('we make backups').to_s)
+  end
+
+  def test_keeps_a_short_text
+    assert_equal("a\nb", Rsk::Trimmed.new("a\nb", 100).to_s)
+  end
+
+  def test_cuts_on_a_line_boundary
+    assert_equal("one\ntwo...", Rsk::Trimmed.new("one\ntwo\nthree and more", 12).to_s)
+  end
+
+  def test_cuts_a_single_line
+    assert_equal('abcde...', Rsk::Trimmed.new('abcdefghij', 5).to_s)
+  end
+end


### PR DESCRIPTION
Every message is sent with `parse_mode: 'Markdown'` and its text is built by
interpolating free-form user input, so a cause named `review [pending] docs` or
`budget_2026_q1` produced an unbalanced entity and the Bot API answered 400. The
fixed-offset truncation could cut mid-entity and do the same. `broadcast` and
`alone` only logged that, so the user's notifications stopped for good, silently.

User text is escaped before it goes in, the truncation lands on a line boundary,
and the swallowed exception is reported to Sentry the way `dispatch` reports its
own.

Closes #449
