### PR TITLE
#460: complete the plan on the connection the caller holds

### DIFF
--- a/objects/plan.rb
+++ b/objects/plan.rb
@@ -16,22 +16,18 @@ class Rsk::Plan
     @part = part
   end
 
-  def detach
+  def detach(con: nil)
+    return detach_in(con) unless con.nil?
     @pgsql.transaction do |t|
-      project = pid(t)
-      if t.exec('SELECT * FROM part WHERE id = $1 AND project = $2', [@part, project]).empty?
-        raise(Rsk::Urror, "##{@id} is not in your project ##{project}")
-      end
-      t.exec('DELETE FROM plan WHERE id = $1 AND part = $2', [@id, @part])
-      t.exec('DELETE FROM part WHERE id = $1', [@id]) if t.exec('SELECT * FROM plan WHERE id = $1', [@id]).empty?
+      detach_in(t)
     end
   end
 
-  def complete(time: Time.now - (4 * 60 * 60))
-    if /^[a-z]+$/.match?(schedule)
-      @pgsql.exec('UPDATE plan SET completed = $3 WHERE id = $1 AND part = $2', [@id, @part, time])
+  def complete(time: Time.now - (4 * 60 * 60), con: nil)
+    if /^[a-z]+$/.match?(schedule(con:))
+      (con || @pgsql).exec('UPDATE plan SET completed = $3 WHERE id = $1 AND part = $2', [@id, @part, time])
     else
-      detach
+      detach(con:)
     end
   end
 
@@ -54,6 +50,16 @@ class Rsk::Plan
   end
 
   private
+
+  def detach_in(con)
+    project = pid(con)
+    if con.exec('SELECT * FROM part WHERE id = $1 AND project = $2', [@part, project]).empty?
+      raise(Rsk::Urror, "##{@id} is not in your project ##{project}")
+    end
+    con.exec('DELETE FROM plan WHERE id = $1 AND part = $2', [@id, @part])
+    return unless con.exec('SELECT * FROM plan WHERE id = $1', [@id]).empty?
+    con.exec('DELETE FROM part WHERE id = $1', [@id])
+  end
 
   def pid(con)
     row = con.exec('SELECT project FROM part WHERE id = $1 FOR UPDATE', [@id]).first

--- a/objects/plan.rb
+++ b/objects/plan.rb
@@ -17,9 +17,9 @@ class Rsk::Plan
   end
 
   def detach(con: nil)
-    return detach_in(con) unless con.nil?
+    return wipe(con) unless con.nil?
     @pgsql.transaction do |t|
-      detach_in(t)
+      wipe(t)
     end
   end
 
@@ -51,7 +51,7 @@ class Rsk::Plan
 
   private
 
-  def detach_in(con)
+  def wipe(con)
     project = pid(con)
     if con.exec('SELECT * FROM part WHERE id = $1 AND project = $2', [@part, project]).empty?
       raise(Rsk::Urror, "##{@id} is not in your project ##{project}")

--- a/objects/tasks.rb
+++ b/objects/tasks.rb
@@ -27,7 +27,7 @@ class Rsk::Tasks
     row = plan(id)
     @pgsql.transaction do |t|
       t.exec('DELETE FROM task WHERE id = $1', [id])
-      Rsk::Plans.new(@pgsql, Integer(row['project'])).get(Integer(row['id']), Integer(row['part'])).complete
+      Rsk::Plans.new(@pgsql, Integer(row['project'])).get(Integer(row['id']), Integer(row['part'])).complete(con: t)
     end
   end
 

--- a/test/test_tasks.rb
+++ b/test/test_tasks.rb
@@ -79,6 +79,31 @@ class Rsk::TasksTest < TestCase
     refute_equal(schedule, plan.schedule)
   end
 
+  def test_completes_a_dated_plan_with_one_connection
+    pgsql = Pgtk::Pool.new(
+      Pgtk::Wire::Yaml.new(File.join(__dir__, '../target/pgsql-config.yml')),
+      max: 1,
+      timeout: 0.1,
+      log: Loog::NULL
+    )
+    pgsql.start!
+    login = "bobbyD#{SecureRandom.hex(8)}"
+    project = Rsk::Projects.new(pgsql, login).add("test#{SecureRandom.hex(8)}")
+    eid = Rsk::Effects.new(pgsql, project).add('business will stop')
+    Rsk::Triples.new(pgsql, project).add(
+      Rsk::Causes.new(pgsql, project).add('we have data'),
+      Rsk::Risks.new(pgsql, project).add('we may lose it'), eid
+    )
+    plans = Rsk::Plans.new(pgsql, project)
+    pid = plans.add(eid, 'solve it!')
+    plans.get(pid, eid).reschedule((Time.now - (5 * 24 * 60 * 60)).strftime('%d-%m-%Y'))
+    tasks = Rsk::Tasks.new(pgsql, login)
+    tasks.create
+    tasks.done(tasks.fetch[0][:id])
+    assert_equal(0, tasks.count)
+    assert_empty(pgsql.exec('SELECT * FROM plan WHERE id = $1 AND part = $2', [pid, eid]))
+  end
+
   def test_resolves_the_owning_project
     login = "bobbyP#{SecureRandom.hex(8)}"
     project = Rsk::Projects.new(test_pgsql, login).add("test#{SecureRandom.hex(8)}")


### PR DESCRIPTION
`done` deleted the `task` row inside a transaction and then called `complete`, which for a dated plan went to `detach` and opened a second connection to delete the `plan` and `part` rows. That delete needs a lock on the referencing `task` row the outer transaction still holds, so the two waited for each other and `done` never returned. `complete` and `detach` take `con:` now, the way `schedule` and `reschedule` already do, and `done` passes its own.

The new test uses a pool of one connection, like `test_postpones_tasks_with_one_connection` right above it.

Closes #460
