### PR TITLE
#470: read the triple on the connection the caller holds

### DIFF
--- a/objects/triples.rb
+++ b/objects/triples.rb
@@ -39,7 +39,7 @@ class Rsk::Triples
 
   def delete(id)
     @pgsql.transaction do |t|
-      triple = fetch(id: Integer(id))[0]
+      triple = fetch(id: Integer(id), con: t)[0]
       raise(Rsk::Urror, "Triple ##{id} not found in your project ##{@project}") if triple.nil?
       if t.exec('SELECT * FROM part WHERE id = $1 AND project = $2', [triple[:cid], @project]).empty?
         raise(Rsk::Urror, "Triple ##{id} is not in your project ##{@project}")
@@ -61,8 +61,8 @@ class Rsk::Triples
     query(0, query).count
   end
 
-  def fetch(id: 0, query: '', limit: 10, offset: 0)
-    query(id, query).fetch(offset, limit).map do |r|
+  def fetch(id: 0, query: '', limit: 10, offset: 0, con: nil)
+    query(id, query, con).fetch(offset, limit).map do |r|
       {
         id: Integer(r['id']),
         cid: Integer(r['cid']),
@@ -85,7 +85,7 @@ class Rsk::Triples
 
   private
 
-  def query(id, query)
+  def query(id, query, con = nil)
     where = []
     words = []
     unless id.positive?
@@ -105,7 +105,7 @@ class Rsk::Triples
       end
     end
     Rsk::Query.new(
-      @pgsql,
+      con || @pgsql,
       [
         'SELECT DISTINCT t.id, t.created, cause.id AS cid, risk.id AS rid, effect.id AS eid,',
         '  effect.positive,',

--- a/test/test_triples.rb
+++ b/test/test_triples.rb
@@ -39,6 +39,26 @@ class Rsk::TriplesTest < TestCase
     assert_includes(triples.fetch[0][:plans][0][:text], "pay the bill\nand check it")
   end
 
+  def test_deletes_with_one_connection
+    pgsql = Pgtk::Pool.new(
+      Pgtk::Wire::Yaml.new(File.join(__dir__, '../target/pgsql-config.yml')),
+      max: 1,
+      timeout: 0.1,
+      log: Loog::NULL
+    )
+    pgsql.start!
+    project = Rsk::Projects.new(pgsql, "bobbyT#{SecureRandom.hex(8)}").add("test#{SecureRandom.hex(8)}")
+    triples = Rsk::Triples.new(pgsql, project)
+    triples.delete(
+      triples.add(
+        Rsk::Causes.new(pgsql, project).add('we have data'),
+        Rsk::Risks.new(pgsql, project).add('we may lose it'),
+        Rsk::Effects.new(pgsql, project).add('business will stop')
+      )
+    )
+    assert_equal(0, triples.count)
+  end
+
   def test_rejects_cross_project_parts
     project = test_project
     rid = test_risk(project: project)


### PR DESCRIPTION
`Triples#delete` opened a transaction and then called `fetch`, which built its query on
`@pgsql` instead of the connection the transaction holds. So one call took two connections
at once and the read did not see what the transaction had done; with a pool of one it
waited for a connection it was holding itself.

`fetch` and the private `query` now take the connection, the way `Plan#schedule` and
`Plan#reschedule` take `con:`, and `delete` passes its own. The test runs the delete
against a pool of one connection, which times out without the change.

Closes #470
