### PR TITLE
#471: take the plans with the highest rank first

### DIFF
--- a/objects/pipeline.rb
+++ b/objects/pipeline.rb
@@ -24,7 +24,8 @@ class Rsk::Pipeline
         'JOIN effect ON triple.effect = effect.id',
         'LEFT JOIN task ON task.plan = plan.id',
         'WHERE project.login = $1 AND task.id IS NULL',
-        'GROUP BY plan.id, plan.completed, plan.schedule'
+        'GROUP BY plan.id, plan.completed, plan.schedule',
+        'ORDER BY rank DESC'
       ],
       [@login]
     ).filter_map do |p|

--- a/test/test_pipeline.rb
+++ b/test/test_pipeline.rb
@@ -7,6 +7,7 @@ require_relative 'test__helper'
 
 require_relative '../objects/causes'
 require_relative '../objects/effects'
+require_relative '../objects/pipeline'
 require_relative '../objects/plans'
 require_relative '../objects/projects'
 require_relative '../objects/risks'
@@ -29,5 +30,30 @@ class Rsk::PipelineTest < TestCase
     pipeline = Rsk::Pipeline.new(test_pgsql, login)
     assert_equal(1, pipeline.fetch.count)
     assert(pipeline.fetch.any?(pid))
+  end
+
+  def test_fetches_the_higher_rank_first
+    login = "bobbyR#{SecureRandom.hex(8)}"
+    project = Rsk::Projects.new(test_pgsql, login).add("test#{SecureRandom.hex(8)}")
+    plans = Rsk::Plans.new(test_pgsql, project)
+    assert_equal(
+      [1, 9].map { |weight| planned(project, plans, weight) }[1],
+      Rsk::Pipeline.new(test_pgsql, login).fetch.first
+    )
+  end
+
+  private
+
+  def planned(project, plans, weight)
+    rid = Rsk::Risks.new(test_pgsql, project).add("we may lose it #{weight}")
+    eid = Rsk::Effects.new(test_pgsql, project).add("business will stop #{weight}")
+    Rsk::Risks.new(test_pgsql, project).get(rid).weigh(weight)
+    Rsk::Effects.new(test_pgsql, project).get(eid).weigh(weight)
+    Rsk::Triples.new(test_pgsql, project).add(
+      Rsk::Causes.new(test_pgsql, project).add("we have data #{weight}"), rid, eid
+    )
+    pid = plans.add(eid, "solve it #{weight}!")
+    plans.get(pid, eid).reschedule((Time.now - (5 * 24 * 60 * 60)).strftime('%d-%m-%Y'))
+    pid
   end
 end


### PR DESCRIPTION
`Pipeline#fetch` computed a rank for every plan and then returned the rows in whatever
order Postgres gave them. `Tasks#create` stops at the eighth task, so when more than eight
plans were due, which eight became tasks had nothing to do with the rank that was computed
for exactly that choice.

The query orders by rank, descending. The test makes two due plans with different weights
and asserts the heavier one comes first.

Closes #471
