### PR TITLE
#468: set the login cookie with HttpOnly and SameSite

### DIFF
--- a/front/front_login.rb
+++ b/front/front_login.rb
@@ -9,7 +9,7 @@ before '/*' do
   end
   @locals = { http_start: Time.now, ver: Rsk::VERSION, login_link: settings.glogin.login_uri, request_ip: request.ip }
   if params[:glogin] && ENV['RACK_ENV'] != 'production'
-    response.set_cookie('glogin', params[:glogin])
+    response.set_cookie('glogin', value: params[:glogin], path: '/', httponly: true, same_site: :lax)
   end
   if request.cookies['glogin']
     begin
@@ -29,11 +29,15 @@ get '/github-callback' do
   code = params[:code]
   error(400) if code.nil?
   response.set_cookie(
-    :glogin, GLogin::Cookie::Open.new(
+    :glogin,
+    value: GLogin::Cookie::Open.new(
       settings.glogin.user(code),
       settings.config['github']['encryption_secret'],
       context
-    ).to_s
+    ).to_s,
+    path: '/',
+    httponly: true,
+    same_site: :lax
   )
   flash('/', 'You have been logged in')
 end

--- a/test/test_0rsk.rb
+++ b/test/test_0rsk.rb
@@ -176,6 +176,13 @@ class Rsk::AppTest < TestCase
     end
   end
 
+  def test_login_cookie_is_protected
+    get('/?glogin=bob')
+    cookie = last_response.headers['Set-Cookie'].to_s
+    assert_includes(cookie.downcase, 'httponly', cookie)
+    assert_includes(cookie.downcase, 'samesite=lax', cookie)
+  end
+
   def test_deletes_ranked
     pid = login("deleter#{rand(99_999)}")
     post(


### PR DESCRIPTION
The login cookie was set with nothing but its value. `Rack::SSL` appends `secure` and
nothing else, so the cookie was readable by JavaScript and travelled with cross-site
requests, while it is the whole session.

Both places that set it now pass `httponly: true` and `same_site: :lax`, with an explicit
path.

Closes #468
