### PR TITLE
#469: take the glogin parameter only in the tests

### DIFF
--- a/front/front_login.rb
+++ b/front/front_login.rb
@@ -8,7 +8,7 @@ before '/*' do
     halt 429, { 'Content-Type' => 'text/plain' }, 'Too many requests'
   end
   @locals = { http_start: Time.now, ver: Rsk::VERSION, login_link: settings.glogin.login_uri, request_ip: request.ip }
-  if params[:glogin] && ENV['RACK_ENV'] != 'production'
+  if params[:glogin] && settings.environment == :test
     response.set_cookie('glogin', params[:glogin])
   end
   if request.cookies['glogin']

--- a/test/test_0rsk.rb
+++ b/test/test_0rsk.rb
@@ -176,6 +176,16 @@ class Rsk::AppTest < TestCase
     end
   end
 
+  def test_ignores_the_glogin_param_outside_the_tests
+    app.set(:environment, :development)
+    begin
+      get('/?glogin=bob', {}, 'HTTP_HOST' => 'localhost')
+      refute_includes(last_response.headers['Set-Cookie'].to_s, 'glogin=bob')
+    ensure
+      app.set(:environment, :test)
+    end
+  end
+
   def test_deletes_ranked
     pid = login("deleter#{rand(99_999)}")
     post(


### PR DESCRIPTION
The branch that lets a query parameter set the login cookie was guarded by
`ENV['RACK_ENV'] != 'production'`. The variable is set to `test` in the `Rakefile` and
nowhere else in the repository, so on a host where it is missing the branch is live and a
link can hand a prepared identity to a visitor.

The guard is `settings.environment == :test` now, which is what the branch is for.

Closes #469
