### PR TITLE
#472: aggregate the plans as JSON, not as a string

### DIFF
--- a/objects/triples.rb
+++ b/objects/triples.rb
@@ -76,9 +76,8 @@ class Rsk::Triples
         impact: Integer(r['impact']),
         positive: r['positive'] == 't',
         rank: Integer(r['rank']),
-        plans: r['plans'] == '{NULL}' ? [] : JSON.parse("[#{r['plans'][1..-2]}]").map do |p|
-          id, text = p.split(':', 2)
-          { id: Integer(id), text: text }
+        plans: JSON.parse(r['plans']).filter_map do |p|
+          { id: Integer(p['id']), text: p['text'] } unless p['id'].nil?
         end
       }
     end
@@ -114,7 +113,7 @@ class Rsk::Triples
         '  risk.probability AS probability, effect.impact AS impact,',
         '  cpart.text AS ctext, rpart.text AS rtext, epart.text AS etext,',
         '  (probability * impact) AS rank,',
-        '  ARRAY_AGG(ppart.id || \':\' || ppart.text || \' (\' || plan.schedule || \')\')',
+        '  JSONB_AGG(JSONB_BUILD_OBJECT(\'id\', ppart.id, \'text\', ppart.text || \' (\' || plan.schedule || \')\'))',
         '    OVER (PARTITION BY t.id) AS plans',
         'FROM triple t',
         'JOIN cause ON cause.id = t.cause',

--- a/test/test_triples.rb
+++ b/test/test_triples.rb
@@ -29,6 +29,16 @@ class Rsk::TriplesTest < TestCase
     triples.fetch.each { |t| triples.delete(t[:id]) }
   end
 
+  def test_fetches_a_plan_whose_text_has_a_newline
+    project = test_project
+    eid = test_effect(project: project)
+    triples = Rsk::Triples.new(test_pgsql, project)
+    triples.add(test_cause(project: project), test_risk(project: project), eid)
+    Rsk::Plans.new(test_pgsql, project).add(eid, "pay the bill\nand check it")
+    assert_equal(1, triples.fetch[0][:plans].count)
+    assert_includes(triples.fetch[0][:plans][0][:text], "pay the bill\nand check it")
+  end
+
   def test_rejects_cross_project_parts
     project = test_project
     rid = test_risk(project: project)


### PR DESCRIPTION
The plans of a triple travelled as `ARRAY_AGG` of `id || ':' || text || ' (' || schedule || ')'`,
and the Ruby side rebuilt them by cutting the braces off the Postgres array and handing the
rest to `JSON.parse`. One plan whose text held a newline broke that parse, and with it
`fetch` for the whole project.

The aggregation is `JSONB_AGG(JSONB_BUILD_OBJECT(...))` now, so the id and the text come
back as a real JSON value and nothing has to be split by hand. `JSONB` rather than `JSON`
because the query selects `DISTINCT`, and `json` has no equality operator.

Closes #472
