### PR TITLE
#465: let Haml escape by default

### DIFF
--- a/0rsk.rb
+++ b/0rsk.rb
@@ -30,7 +30,7 @@ if ENV['RACK_ENV'] != 'test'
 end
 
 configure do
-  set :haml, format: :xhtml, escape_html: false
+  set :haml, format: :xhtml, escape_html: true
   config = { 'github' => { 'client_id' => '?', 'client_secret' => '?', 'encryption_secret' => '' }, 'sentry' => '' }
   cfg = File.join(File.dirname(__FILE__), 'config.yml')
   if File.exist?(cfg)

--- a/test/test_0rsk.rb
+++ b/test/test_0rsk.rb
@@ -176,6 +176,13 @@ class Rsk::AppTest < TestCase
     end
   end
 
+  def test_escapes_html_in_a_flash_message
+    set_cookie('flash_msg=<b>bold</b>')
+    get('/')
+    refute_includes(last_response.body, '<b>bold</b>', last_response.body)
+    assert_includes(last_response.body, '&lt;b&gt;bold&lt;/b&gt;', last_response.body)
+  end
+
   def test_deletes_ranked
     pid = login("deleter#{rand(99_999)}")
     post(

--- a/views/causes.haml
+++ b/views/causes.haml
@@ -53,4 +53,4 @@
             = rank(r)
           %td.right
             = r[:risks]
-    = Tilt::HamlTemplate.new('views/_paging.haml', 1, format: :xhtml).render(self, locals.merge(count: causes.count))
+    != Tilt::HamlTemplate.new('views/_paging.haml', 1, format: :xhtml).render(self, locals.merge(count: causes.count))

--- a/views/effects.haml
+++ b/views/effects.haml
@@ -49,4 +49,4 @@
             = rank(r)
           %td.right
             = r[:risks]
-    = Tilt::HamlTemplate.new('views/_paging.haml', 1, format: :xhtml).render(self, locals.merge(count: effects.count))
+    != Tilt::HamlTemplate.new('views/_paging.haml', 1, format: :xhtml).render(self, locals.merge(count: effects.count))

--- a/views/layout.haml
+++ b/views/layout.haml
@@ -77,7 +77,7 @@
           %p{style: 'background-color:' + flash_color + ';color:white;padding:.1em .5em;border-radius:4px;width:100%;'}
             = flash_msg
       %article
-        = yield
+        != yield
       %footer.small.gray
         - if defined?(user)
           %nav

--- a/views/plans.haml
+++ b/views/plans.haml
@@ -54,4 +54,4 @@
           %td.right
             = thumb(r)
             = rank(r)
-    = Tilt::HamlTemplate.new('views/_paging.haml', 1, format: :xhtml).render(self, locals.merge(count: plans.count))
+    != Tilt::HamlTemplate.new('views/_paging.haml', 1, format: :xhtml).render(self, locals.merge(count: plans.count))

--- a/views/ranked.haml
+++ b/views/ranked.haml
@@ -53,4 +53,4 @@
           %span.small{style: 'margin-left: 2em;'}
             %code.small= "P#{p[:id]}"
             &= p[:text]
-  = Tilt::HamlTemplate.new('views/_paging.haml', 1, format: :xhtml).render(self, locals.merge(count: triples.count))
+  != Tilt::HamlTemplate.new('views/_paging.haml', 1, format: :xhtml).render(self, locals.merge(count: triples.count))

--- a/views/risks.haml
+++ b/views/risks.haml
@@ -48,4 +48,4 @@
             = rank(r)
           %td.right
             = r[:effects]
-  = Tilt::HamlTemplate.new('views/_paging.haml', 1, format: :xhtml).render(self, locals.merge(count: risks.count))
+  != Tilt::HamlTemplate.new('views/_paging.haml', 1, format: :xhtml).render(self, locals.merge(count: risks.count))

--- a/views/tasks.haml
+++ b/views/tasks.haml
@@ -73,7 +73,7 @@
               %form{action: iri.cut('/tasks/later').add(id: t[:id], period: period), method: 'POST', style: 'display:inline'}
                 %button{type: 'submit', title: 'Postpone', style: 'background:none;border:none;padding:0;color:inherit;font:inherit;cursor:pointer'}
                   = period
-  = Tilt::HamlTemplate.new('views/_paging.haml', 1, format: :xhtml).render(self, locals.merge(count: tasks.count))
+  != Tilt::HamlTemplate.new('views/_paging.haml', 1, format: :xhtml).render(self, locals.merge(count: tasks.count))
 
 %p
   We're checking all your plans regularly and create tasks


### PR DESCRIPTION
Haml was configured with `escape_html: false`, so anything printed with `=` went into the
page as HTML. The flash message is printed that way and it carries text that came from the
request, for example the raw `id` that `number` puts into its error.

Escaping is on now. The two places that really print HTML say so with `!=`: the `yield` in
the layout and the `_paging` partial that six pages render. Everything else in the views
already used `&=` or plain text, so nothing else changes.

Closes #465
