### PR TITLE
#467: make the routes that change data POST

### DIFF
--- a/0rsk.rb
+++ b/0rsk.rb
@@ -94,7 +94,7 @@ get '/projects' do
   haml :projects, layout: :layout, locals: merged(title: '/projects', projects: projects.fetch)
 end
 
-get '/projects/select' do
+post '/projects/select' do
   pid = params[:id]
   response.set_cookie('0rsk-project', pid)
   flash('/ranked', "Project ##{pid} selected")
@@ -103,7 +103,8 @@ end
 post '/projects/create' do
   title = params[:title]
   pid = projects.add(title)
-  flash("/projects/select?id=#{pid}", "A new project ##{pid} selected")
+  response.set_cookie('0rsk-project', pid.to_s)
+  flash('/ranked', "A new project ##{pid} selected")
 end
 
 post '/projects/delete' do

--- a/front/front_tasks.rb
+++ b/front/front_tasks.rb
@@ -32,19 +32,19 @@ get '/tasks' do
   )
 end
 
-get '/tasks/done' do
+post '/tasks/done' do
   id = number(params[:id], 'id')
   tasks.done(id)
   flash('/tasks', "Thanks, task ##{id} was completed!")
 end
 
-get '/tasks/later' do
+post '/tasks/later' do
   id = number(params[:id], 'id')
   tasks.postpone(id, Rsk::Postpone.new(params[:period]).seconds)
   flash('/tasks', "Thanks, the task ##{id} was postponed")
 end
 
-get '/tasks/create' do
+post '/tasks/create' do
   tasks.create
   flash('/tasks', 'All necessary tasks were created, thanks!')
 end

--- a/test/test_0rsk.rb
+++ b/test/test_0rsk.rb
@@ -117,7 +117,7 @@ class Rsk::AppTest < TestCase
       post('/triple/save', "ctext=c#{salt}&rtext=r#{salt}&etext=e#{salt}&emoji=A&cid=&rid=&eid=&#{tail}")
       refute_includes(last_response.body, '<pre', "#{tail} shows a backtrace: #{last_response.body}")
     end
-    get('/tasks/done?id=abc')
+    post('/tasks/done?id=abc')
     refute_includes(last_response.body, '<pre', last_response.body)
   end
 
@@ -129,6 +129,14 @@ class Rsk::AppTest < TestCase
     cookie = last_response.headers['Set-Cookie']
     refute_nil(cookie, last_response.body)
     assert_includes(cookie.to_s, 'glogin=', last_response.body)
+  end
+
+  def test_refuses_to_change_data_over_get
+    login
+    %w[/tasks/done?id=1 /tasks/later?id=1&period=week /tasks/create /projects/select?id=1].each do |uri|
+      get(uri)
+      assert_equal(404, last_response.status, uri)
+    end
   end
 
   def test_deletes_ranked

--- a/views/projects.haml
+++ b/views/projects.haml
@@ -19,8 +19,9 @@
   - projects.each do |p|
     %p
       = "##{p[:id]}:"
-      %a{href: iri.cut('/projects/select').add(id: p[:id]), title: 'Click to pick this project'}<
-        &= p[:title]
+      %form{action: iri.cut('/projects/select').add(id: p[:id]), method: 'POST', style: 'display:inline'}
+        %button{type: 'submit', title: 'Click to pick this project', style: 'background:none;border:none;padding:0;color:inherit;font:inherit;cursor:pointer'}
+          &= p[:title]
       %br
       %span.small
         %form{action: iri.cut('/projects/delete').add(id: p[:id]), method: 'POST', style: 'display:inline', onsubmit: "return confirm('Are sure you want to delete it?')"}

--- a/views/tasks.haml
+++ b/views/tasks.haml
@@ -62,21 +62,25 @@
           &= t[:title]
         %span.item<
           &= t[:schedule]
-        %a.item{href: iri.cut('/tasks/done').add(id: t[:id]), title: 'Mark as done'} Done
+        %form.item{action: iri.cut('/tasks/done').add(id: t[:id]), method: 'POST', style: 'display:inline'}
+          %button{type: 'submit', title: 'Mark as done', style: 'background:none;border:none;padding:0;color:inherit;font:inherit;cursor:pointer'}
+            Done
         - unless /^[a-z]+$/.match?(t[:schedule])
           %span.item
             Later:
-            %a{href: iri.cut('/tasks/later'), title: 'Postpone'.add(id: t[:id], period: 'week')} week
-            = '|'
-            %a{href: iri.cut('/tasks/later'), title: 'Postpone'.add(id: t[:id], period: 'month')} month
-            = '|'
-            %a{href: iri.cut('/tasks/later'), title: 'Postpone'.add(id: t[:id], period: 'quarter')} quarter
+            - %w[week month quarter].each_with_index do |period, i|
+              = '|' unless i.zero?
+              %form{action: iri.cut('/tasks/later').add(id: t[:id], period: period), method: 'POST', style: 'display:inline'}
+                %button{type: 'submit', title: 'Postpone', style: 'background:none;border:none;padding:0;color:inherit;font:inherit;cursor:pointer'}
+                  = period
   = Tilt::HamlTemplate.new('views/_paging.haml', 1, format: :xhtml).render(self, locals.merge(count: tasks.count))
 
 %p
   We're checking all your plans regularly and create tasks
   accordingly, when time comes. You can
-  %a{href: iri.cut('/tasks/create'), title: 'Pull latest plans'} click here
+  %form{action: iri.cut('/tasks/create'), method: 'POST', style: 'display:inline'}
+    %button{type: 'submit', title: 'Pull latest plans', style: 'background:none;border:none;padding:0;color:inherit;font:inherit;cursor:pointer'}
+      click here
   to pull the latest plans in, right now.
   - if updated
     The last time plans were checked


### PR DESCRIPTION
`/tasks/done`, `/tasks/later`, `/tasks/create` and `/projects/select` changed data over
GET, so any page a logged in user opened could fire them, an `img` tag being enough.

All four are POST now, and the links that reached them are inline forms with a submit
button, the same shape `/projects/delete` and `/logout` already use. `/projects/create`
used to redirect to `/projects/select?id=...` to pick the new project; it sets the cookie
itself now.

The `SameSite` half of the report is #468.

Closes #467
