### PR TITLE
#466: bind a Telegram chat by a one-time token

### DIFF
--- a/front/front_telegram.rb
+++ b/front/front_telegram.rb
@@ -12,8 +12,11 @@ require_relative '../objects/trimmed'
 require_relative '../objects/urror'
 
 get '/telegram' do
-  id = Integer(params[:id])
-  telechats.add(id, identity)
+  haml :telegram, layout: :layout, locals: merged(title: '/telegram', token: params[:token].to_s)
+end
+
+post '/telegram' do
+  id = telechats.accept(params[:token].to_s, identity)
   telepost("We identified you as [@#{identity}](https://github.com/#{identity}), thanks!")
   flash('/', "Your account linked with Telegram chat ##{id}, thanks!")
 end
@@ -218,7 +221,10 @@ if settings.config['telegram']
       if telechats.exists?(chat)
         dispatch(chat, message)
       else
-        telepost("[Click here](https://www.0rsk.com/telegram?id=#{chat}) to identify yourself.", chat)
+        telepost(
+          "[Click here](https://www.0rsk.com/telegram?token=#{telechats.invite(chat)}) to identify yourself.",
+          chat
+        )
       end
     end
   rescue Net::ReadTimeout => e

--- a/liquibase/2019/016-teleinvite.xml
+++ b/liquibase/2019/016-teleinvite.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+* SPDX-License-Identifier: MIT
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd" logicalFilePath="001-initial-schema.xml">
+  <changeSet id="016" author="yegor256">
+    <sql>
+      CREATE TABLE teleinvite (
+        token TEXT PRIMARY KEY,
+        chat BIGINT NOT NULL,
+        created TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      );
+    </sql>
+  </changeSet>
+</databaseChangeLog>

--- a/objects/telechats.rb
+++ b/objects/telechats.rb
@@ -3,7 +3,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
+require 'securerandom'
 require_relative 'rsk'
+require_relative 'urror'
 
 class Rsk::Telechats
   def initialize(pgsql)
@@ -12,6 +14,22 @@ class Rsk::Telechats
 
   def add(id, login)
     @pgsql.exec('INSERT INTO telechat (id, login) VALUES ($1, $2)', [id, login])
+  end
+
+  def invite(chat)
+    token = SecureRandom.uuid
+    @pgsql.exec('INSERT INTO teleinvite (token, chat) VALUES ($1, $2)', [token, chat])
+    token
+  end
+
+  def accept(token, login)
+    @pgsql.transaction do |t|
+      rows = t.exec('DELETE FROM teleinvite WHERE token = $1 RETURNING chat', [token])
+      raise(Rsk::Urror, 'This link is not valid any more, ask the bot for a new one') if rows.empty?
+      chat = Integer(rows[0]['chat'])
+      t.exec('INSERT INTO telechat (id, login) VALUES ($1, $2)', [chat, login])
+      chat
+    end
   end
 
   def exists?(id)

--- a/test/test_telechats.rb
+++ b/test/test_telechats.rb
@@ -46,6 +46,21 @@ class Rsk::TelechatsTest < TestCase
     end
   end
 
+  def test_binds_a_chat_by_a_one_time_token
+    login = "judyIN#{SecureRandom.hex(8)}"
+    telechats = Rsk::Telechats.new(test_pgsql)
+    chat = SecureRandom.random_number(2_000_000_000) + 1
+    token = telechats.invite(chat)
+    assert_equal(chat, telechats.accept(token, login))
+    assert_equal(login, telechats.login(chat))
+    assert_raises(Rsk::Urror) { telechats.accept(token, login) }
+  end
+
+  def test_refuses_a_token_it_never_gave
+    telechats = Rsk::Telechats.new(test_pgsql)
+    assert_raises(Rsk::Urror) { telechats.accept(SecureRandom.uuid, "judyNO#{SecureRandom.hex(8)}") }
+  end
+
   def test_accepts_a_modern_telegram_chat
     login = "judyBI#{SecureRandom.hex(8)}"
     telechats = Rsk::Telechats.new(test_pgsql)

--- a/views/telegram.haml
+++ b/views/telegram.haml
@@ -1,0 +1,8 @@
+- # SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+- # SPDX-License-Identifier: MIT
+%p
+  Confirm that you want to link this account with the Telegram chat
+  the bot sent you the link from.
+%form{action: iri.cut('/telegram'), method: 'POST'}
+  %input{type: 'hidden', name: 'token', value: token}
+  %input{type: 'submit', value: 'Link'}


### PR DESCRIPTION
`GET /telegram?id=<chat>` bound whatever chat id it was given to whoever was logged in. The
id is not a secret, the bot prints it into a message that everyone in a group chat can
read, so any logged in user could bind any chat and then read another person's agenda and
complete their tasks.

The bot now stores a one-time token for the chat and puts the token in the link. `GET
/telegram` only shows a confirmation form; `POST /telegram` looks the chat up by the token,
deletes the token in the same transaction, and binds it. A token that was used, or one the
server never gave, is refused.

Closes #466
