### PR TITLE
#324 Dashboard view with Chart.js

### DIFF
--- a/0rsk.rb
+++ b/0rsk.rb
@@ -285,6 +285,69 @@ get '/effects.csv' do
   )
 end
 
+get '/dashboard' do
+  haml :dashboard, layout: :layout, locals: merged(title: '/dashboard')
+end
+
+get '/dashboard.json' do
+  content_type 'application/json'
+  pid = request.cookies['0rsk-project']
+  unless pid && projects.exists?(pid)
+    halt 200, JSON.generate(heatmap: [], distribution: [], coverage: { total: 0, with_plans: 0, without_plans: 0 })
+  end
+  pg = settings.pgsql
+  heatmap =
+    pg.exec(
+      [
+        'SELECT risk.probability, effect.impact, COUNT(t.id) AS cnt',
+        'FROM triple t',
+        'JOIN part AS cpart ON t.cause = cpart.id',
+        'JOIN risk ON t.risk = risk.id',
+        'JOIN effect ON t.effect = effect.id',
+        'WHERE cpart.project = $1',
+        'GROUP BY risk.probability, effect.impact',
+        'ORDER BY risk.probability, effect.impact'
+      ],
+      [pid]
+    ).map do |r|
+      {
+        probability: Integer(r['probability'], 10), impact: Integer(r['impact'], 10),
+        count: Integer(r['cnt'], 10)
+      }
+    end
+  distribution =
+    pg.exec(
+      [
+        'SELECT (risk.probability * effect.impact) / 10 * 10 AS bucket, COUNT(*) AS cnt',
+        'FROM triple t',
+        'JOIN part AS cpart ON t.cause = cpart.id',
+        'JOIN risk ON t.risk = risk.id',
+        'JOIN effect ON t.effect = effect.id',
+        'WHERE cpart.project = $1',
+        'GROUP BY bucket',
+        'ORDER BY bucket'
+      ],
+      [pid]
+    ).map { |r| { rank: Integer(r['bucket'], 10), count: Integer(r['cnt'], 10) } }
+  coverage = pg.exec(
+    [
+      'SELECT COUNT(*) AS total,',
+      '  COUNT(*) FILTER (WHERE EXISTS (',
+      '    SELECT 1 FROM plan WHERE plan.part IN (t.cause, t.risk, t.effect)',
+      '  )) AS with_plans',
+      'FROM triple t',
+      'JOIN part AS cpart ON t.cause = cpart.id',
+      'WHERE cpart.project = $1'
+    ],
+    [pid]
+  ).map do |r|
+    total = Integer(r['total'], 10)
+    wp = Integer(r['with_plans'], 10)
+    { total: total, with_plans: wp, without_plans: total - wp }
+  end[0]
+  JSON.generate(heatmap: heatmap, distribution: distribution, coverage: coverage)
+end
+
 module Rsk::App
   def identity
     redirect('/') unless @locals[:user]

--- a/test/test_0rsk.rb
+++ b/test/test_0rsk.rb
@@ -75,7 +75,8 @@ class Rsk::AppTest < TestCase
       '/ranked.json',
       '/causes.csv',
       '/risks.csv',
-      '/effects.csv'
+      '/effects.csv',
+      '/dashboard.json'
     ]
     pages.each do |p|
       get(p)
@@ -145,6 +146,32 @@ class Rsk::AppTest < TestCase
     assert_equal(1, data.size)
     assert_equal('test cause', data[0]['cause'])
     assert_equal('test effect', data[0]['effect'])
+  end
+
+  def test_dashboard_json
+    login("dash#{rand(99_999)}")
+    post(
+      '/triple/save',
+      [
+        'ctext=test+cause',
+        'rtext=test+risk',
+        'probability=5',
+        'emoji=A',
+        'etext=test+effect',
+        'impact=5',
+        'cid=',
+        'rid=',
+        'eid='
+      ].join('&')
+    )
+    assert_equal(302, last_response.status, last_response.body)
+    get('/dashboard.json')
+    assert_equal(200, last_response.status, last_response.body)
+    data = JSON.parse(last_response.body)
+    assert_equal(1, data['coverage']['total'])
+    assert_equal(0, data['coverage']['with_plans'])
+    refute_empty(data['heatmap'])
+    refute_empty(data['distribution'])
   end
 
   def test_shows_no_backtrace_on_bad_input

--- a/views/dashboard.haml
+++ b/views/dashboard.haml
@@ -1,0 +1,111 @@
+-# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+-# SPDX-License-Identifier: MIT
+
+%script{src: 'https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js', integrity: 'sha384-vsrfeLOOY6KuIYKDlmVH5UiBmgIdB1oEf7p01YgWHuqmOHfZr374+odEv96n9tNC', crossorigin: 'anonymous'}
+
+%h2
+  Dashboard
+
+.coverage
+  %h3 Coverage
+  %canvas#coverageChart{width: 400, height: 200}
+
+.heatmap
+  %h3 Risk Heatmap
+  %canvas#heatmapChart{width: 400, height: 400}
+
+.distribution
+  %h3 Risk Distribution
+  %canvas#distributionChart{width: 400, height: 200}
+
+%script
+  :javascript
+    (function() {
+      var req = new XMLHttpRequest();
+      req.open('GET', '/dashboard.json', true);
+      req.onload = function() {
+        if (req.status !== 200) { return; }
+        var data = JSON.parse(req.responseText);
+
+        // Coverage chart
+        var cov = data.coverage;
+        if (cov.total > 0) {
+          new Chart(document.getElementById('coverageChart'), {
+            type: 'doughnut',
+            data: {
+              labels: ['With Plans', 'Without Plans'],
+              datasets: [{
+                data: [cov.with_plans, cov.without_plans],
+                backgroundColor: ['#4caf50', '#f44336']
+              }]
+            },
+            options: {
+              responsive: true,
+              plugins: {
+                legend: { position: 'bottom' },
+                tooltip: { callbacks: { label: function(ctx) {
+                  return ctx.label + ': ' + ctx.raw + ' (' + (ctx.raw / cov.total * 100).toFixed(1) + '%)';
+                }}}
+              }
+            }
+          });
+        }
+
+        // Heatmap as a scatter/bar chart
+        if (data.heatmap.length > 0) {
+          var labels = [];
+          var counts = [];
+          data.heatmap.forEach(function(h) {
+            labels.push('P' + h.probability + '/I' + h.impact);
+            counts.push(h.count);
+          });
+          var max = Math.max.apply(null, counts);
+          new Chart(document.getElementById('heatmapChart'), {
+            type: 'bar',
+            data: {
+              labels: labels,
+              datasets: [{
+                label: 'Triples',
+                data: counts,
+                backgroundColor: counts.map(function(c) {
+                  var intensity = c / max;
+                  return 'rgba(255, 99, 132, ' + (0.3 + intensity * 0.7) + ')';
+                })
+              }]
+            },
+            options: {
+              responsive: true,
+              scales: {
+                x: { title: { display: true, text: 'Probability / Impact' } },
+                y: { title: { display: true, text: 'Count' }, beginAtZero: true }
+              },
+              plugins: { legend: { display: false } }
+            }
+          });
+        }
+
+        // Distribution chart
+        if (data.distribution.length > 0) {
+          new Chart(document.getElementById('distributionChart'), {
+            type: 'bar',
+            data: {
+              labels: data.distribution.map(function(d) { return d.rank + '-' + (d.rank + 10); }),
+              datasets: [{
+                label: 'Triples',
+                data: data.distribution.map(function(d) { return d.count; }),
+                backgroundColor: '#2196f3'
+              }]
+            },
+            options: {
+              responsive: true,
+              scales: {
+                x: { title: { display: true, text: 'Rank Range' } },
+                y: { title: { display: true, text: 'Count' }, beginAtZero: true }
+              },
+              plugins: { legend: { display: false } }
+            }
+          });
+        }
+      };
+      req.send();
+    })();

--- a/views/layout.haml
+++ b/views/layout.haml
@@ -94,6 +94,8 @@
                   %a{href: iri.cut('/effects'), title: 'Browse effects'} Effects
                 %li
                   %a{href: iri.cut('/plans'), title: 'Browse plans'} Plans
+                %li
+                  %a{href: iri.cut('/dashboard')} Dashboard
               %li
               %img{src: iri.cut('/telegram-logo.svg'), alt: 'Telegram', style: 'height: 1.1em; vertical-align: middle;'}
               %a{href: 'https://t.me/zerorsk_bot', title: 'Telegram bot'} Talk to me


### PR DESCRIPTION
Fixes #461.
Add /dashboard page with interactive charts using Chart.js via CDN.

- GET /dashboard route renders a Haml view
- Three chart sections:
  - Coverage: doughnut chart (triples with/without plans)
  - Risk Heatmap: bar chart by probability/impact buckets
  - Risk Distribution: bar chart by rank ranges
- Fetches data from /dashboard.json (added in #321) via XHR
- Navigation link added to layout footer (below Plans)

Part of Part 2 dashboard feature.




Supersedes #324 (closed as stale by maintainer cleanup). Resubmitted per the maintainer request, rebased on the latest master; the /dashboard.json endpoint is folded in (the old #321 was closed as superseded by this PR).
