### PR TITLE
#319: add CSV and JSON export endpoints

### DIFF
--- a/0rsk.rb
+++ b/0rsk.rb
@@ -5,6 +5,7 @@
 
 $stdout.sync = true
 
+require 'csv'
 require 'glogin'
 require 'glogin/codec'
 require 'haml'

--- a/0rsk.rb
+++ b/0rsk.rb
@@ -221,6 +221,68 @@ get '/terms' do
   haml :terms, layout: :layout, locals: merged(title: '/terms')
 end
 
+get '/ranked.csv' do
+  q = params[:q] || ''
+  tpls = triples.fetch(query: q, limit: triples.count(query: q))
+  to_csv(
+    'ranked.csv',
+    %w[id cause risk effect probability impact rank positive emoji plans],
+    tpls.map do |t|
+      [
+        t[:id], t[:ctext], t[:rtext], t[:etext],
+        t[:probability], t[:impact], t[:rank], t[:positive], t[:emoji], t[:plans].size
+      ]
+    end
+  )
+end
+
+get '/ranked.json' do
+  content_type 'application/json'
+  q = params[:q] || ''
+  data =
+    triples.fetch(query: q, limit: triples.count(query: q)).map do |t|
+      {
+        id: t[:id], cause: t[:ctext], risk: t[:rtext], effect: t[:etext],
+        probability: t[:probability], impact: t[:impact], rank: t[:rank],
+        positive: t[:positive], emoji: t[:emoji], plans: t[:plans].size
+      }
+    end
+  JSON.generate(data)
+end
+
+get '/causes.csv' do
+  q = params[:q] || ''
+  to_csv(
+    'causes.csv',
+    %w[id text emoji rank risks],
+    causes.fetch(query: q, limit: causes.count(query: q)).map do |c|
+      [c[:id], c[:text], c[:emoji], c[:rank], c[:risks]]
+    end
+  )
+end
+
+get '/risks.csv' do
+  q = params[:q] || ''
+  to_csv(
+    'risks.csv',
+    %w[id text probability rank effects],
+    risks.fetch(query: q, limit: risks.count(query: q)).map do |r|
+      [r[:id], r[:text], r[:probability], r[:rank], r[:effects]]
+    end
+  )
+end
+
+get '/effects.csv' do
+  q = params[:q] || ''
+  to_csv(
+    'effects.csv',
+    %w[id text impact rank risks],
+    effects.fetch(query: q, limit: effects.count(query: q)).map do |e|
+      [e[:id], e[:text], e[:impact], e[:rank], e[:risks]]
+    end
+  )
+end
+
 module Rsk::App
   def identity
     redirect('/') unless @locals[:user]
@@ -279,6 +341,20 @@ module Rsk::App
 
   def iri
     Iri.new(request.url)
+  end
+
+  def cell(text)
+    value = text.to_s
+    value.start_with?('=', '+', '-', '@') ? "'#{value}" : value
+  end
+
+  def to_csv(filename, header, rows)
+    content_type('text/csv; charset=utf-8')
+    headers['Content-Disposition'] = "attachment; filename=\"#{filename}\""
+    CSV.generate do |csv|
+      csv << header
+      rows.each { |row| csv << row.map { |value| cell(value) } }
+    end
   end
 end
 Object.include(Rsk::App)

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@
 
 source 'https://rubygems.org'
 
+gem 'csv', '~>3.3'
 gem 'eslintrb', '~>2.1'
 gem 'faraday-multipart', '~>1.2'
 gem 'glogin', '~>0.14'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,7 @@ GEM
     concurrent-ruby (1.3.8)
     connection_pool (3.0.2)
     crass (1.0.6)
+    csv (3.3.5)
     date (3.5.1)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
@@ -368,6 +369,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  csv (~> 3.3)
   eslintrb (~> 2.1)
   faraday-multipart (~> 1.2)
   glogin (~> 0.14)

--- a/test/test_0rsk.rb
+++ b/test/test_0rsk.rb
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
+require 'json'
 require_relative 'test__helper'
 
 require_relative '../0rsk'
@@ -69,7 +70,12 @@ class Rsk::AppTest < TestCase
       '/causes.json',
       '/risks.json',
       '/effects.json',
-      '/plans.json'
+      '/plans.json',
+      '/ranked.csv',
+      '/ranked.json',
+      '/causes.csv',
+      '/risks.csv',
+      '/effects.csv'
     ]
     pages.each do |p|
       get(p)
@@ -108,6 +114,37 @@ class Rsk::AppTest < TestCase
     assert_equal(302, last_response.status, last_response.body)
     get('/ranked')
     assert_equal(200, last_response.status, last_response.body)
+  end
+
+  def test_export_csv_and_json
+    login("export#{rand(99_999)}")
+    post(
+      '/triple/save',
+      [
+        'ctext=test+cause',
+        'rtext=test+risk',
+        'probability=5',
+        'emoji=A',
+        'etext=test+effect',
+        'impact=5',
+        'cid=',
+        'rid=',
+        'eid='
+      ].join('&')
+    )
+    get('/ranked.csv')
+    assert_equal(200, last_response.status, last_response.body)
+    assert_includes(last_response.headers['Content-Type'], 'text/csv')
+    assert_includes(last_response.headers['Content-Type'], 'charset=utf-8')
+    assert_equal('attachment; filename="ranked.csv"', last_response.headers['Content-Disposition'])
+    assert_includes(last_response.body, 'test cause')
+    assert_includes(last_response.body, 'test effect')
+    get('/ranked.json')
+    assert_equal(200, last_response.status, last_response.body)
+    data = JSON.parse(last_response.body)
+    assert_equal(1, data.size)
+    assert_equal('test cause', data[0]['cause'])
+    assert_equal('test effect', data[0]['effect'])
   end
 
   def test_shows_no_backtrace_on_bad_input


### PR DESCRIPTION
Fixes #463.
New read-only endpoints for data export:

- `GET /ranked.csv` — all triples as CSV
- `GET /ranked.json` — all triples as JSON
- `GET /causes.csv` — causes as CSV
- `GET /risks.csv` — risks as CSV
- `GET /effects.csv` — effects as CSV

All require authentication (same as HTML pages).


Supersedes #319 (closed as stale by maintainer cleanup). Resubmitted per the maintainer request, rebased on the latest master; all review feedback is incorporated.
