### PR TITLE
#398: insert a task only if it is not there yet

### DIFF
--- a/objects/tasks.rb
+++ b/objects/tasks.rb
@@ -19,7 +19,7 @@ class Rsk::Tasks
   def create
     Rsk::Pipeline.new(@pgsql, @login).fetch.each do |p|
       next if count >= THRESHOLD
-      @pgsql.exec('INSERT INTO task (plan) VALUES ($1)', [p])
+      @pgsql.exec('INSERT INTO task (plan) VALUES ($1) ON CONFLICT (plan) DO NOTHING', [p])
     end
   end
 

--- a/test/test_tasks.rb
+++ b/test/test_tasks.rb
@@ -104,6 +104,21 @@ class Rsk::TasksTest < TestCase
     assert_empty(pgsql.exec('SELECT * FROM plan WHERE id = $1 AND part = $2', [pid, eid]))
   end
 
+  def test_creates_the_same_task_from_two_threads
+    login = "bobbyRC#{SecureRandom.hex(8)}"
+    project = Rsk::Projects.new(test_pgsql, login).add("test#{SecureRandom.hex(8)}")
+    eid = Rsk::Effects.new(test_pgsql, project).add('business will stop')
+    Rsk::Triples.new(test_pgsql, project).add(
+      Rsk::Causes.new(test_pgsql, project).add('we have data'),
+      Rsk::Risks.new(test_pgsql, project).add('we may lose it'),
+      eid
+    )
+    plans = Rsk::Plans.new(test_pgsql, project)
+    plans.get(plans.add(eid, 'solve it!'), eid).reschedule((Time.now - (5 * 24 * 60 * 60)).strftime('%d-%m-%Y'))
+    Array.new(2) { Thread.new { Rsk::Tasks.new(test_pgsql, login).create } }.each(&:join)
+    assert_equal(1, Rsk::Tasks.new(test_pgsql, login).count)
+  end
+
   def test_resolves_the_owning_project
     login = "bobbyP#{SecureRandom.hex(8)}"
     project = Rsk::Projects.new(test_pgsql, login).add("test#{SecureRandom.hex(8)}")


### PR DESCRIPTION
`Tasks#create` asked the pipeline which plans have no task and then inserted, so two
callers that asked at the same time both got the same plan and raced on
`UNIQUE(plan)`. Both the daemon and `POST /tasks/create` call it, so the race is reachable.

The insert says `ON CONFLICT (plan) DO NOTHING` now, which is what "the task is already
there" means here.

The test runs `create` from two threads at once. On `master` it fails every time:

```
Minitest::UnexpectedError: PG::UniqueViolation: ERROR: duplicate key value violates unique constraint "task_plan_key"
```

Closes #398
