### PR TITLE
#484: refuse a plan that is not in the project

### DIFF
--- a/objects/plans.rb
+++ b/objects/plans.rb
@@ -29,8 +29,13 @@ class Rsk::Plans
     end
   end
 
-  def get(id, part)
+  def get(id, part, con: nil)
     require_relative('plan')
+    if (con || @pgsql).exec(
+      'SELECT id FROM part WHERE id = $1 AND project = $2 AND type = $3', [id, @project, 'Plan']
+    ).empty?
+      raise(Rsk::Urror, "Plan ##{id} is not in project ##{@project}")
+    end
     Rsk::Plan.new(@pgsql, id, part)
   end
 

--- a/objects/tasks.rb
+++ b/objects/tasks.rb
@@ -27,7 +27,9 @@ class Rsk::Tasks
     row = plan(id)
     @pgsql.transaction do |t|
       t.exec('DELETE FROM task WHERE id = $1', [id])
-      Rsk::Plans.new(@pgsql, Integer(row['project'])).get(Integer(row['id']), Integer(row['part'])).complete(con: t)
+      Rsk::Plans.new(@pgsql, Integer(row['project']))
+        .get(Integer(row['id']), Integer(row['part']), con: t)
+        .complete(con: t)
     end
   end
 
@@ -35,7 +37,7 @@ class Rsk::Tasks
     row = plan(id)
     @pgsql.transaction do |t|
       t.exec('DELETE FROM task WHERE id = $1', [id])
-      plan = Rsk::Plans.new(@pgsql, Integer(row['project'])).get(Integer(row['id']), Integer(row['part']))
+      plan = Rsk::Plans.new(@pgsql, Integer(row['project'])).get(Integer(row['id']), Integer(row['part']), con: t)
       raise(Rsk::Urror, "Can't postpone plan ##{row['id']}") if /^[a-z]+$/.match?(plan.schedule(con: t))
       plan.reschedule((Time.now + seconds).strftime('%d-%m-%Y'), con: t)
     end

--- a/test/test_plans.rb
+++ b/test/test_plans.rb
@@ -42,6 +42,20 @@ class Rsk::PlansTest < TestCase
     assert_equal(0, Rsk::Plans.new(test_pgsql, theirs).count)
   end
 
+  def test_refuses_a_plan_of_another_project
+    mine = test_project
+    theirs = test_project
+    rid = test_risk(project: theirs)
+    alien = Rsk::Plans.new(test_pgsql, theirs).add(rid, 'we make backups')
+    assert_includes(
+      assert_raises(Rsk::Urror) do
+        Rsk::Plans.new(test_pgsql, mine).get(alien, rid)
+      end.message,
+      "is not in project ##{mine}"
+    )
+    assert_equal(1, Rsk::Plans.new(test_pgsql, theirs).count)
+  end
+
   def test_fetch_no_duplicates
     pid = test_project
     cid = test_cause(project: pid)


### PR DESCRIPTION
`Plans#get` was the only accessor of its family that took an id straight from the caller and
handed back the object. `Causes#get`, `Risks#get` and `Effects#get` all refuse a part that is not
in the project first. `Plan#wipe` has a check of its own, but it reads the project out of the plan
itself, so it only says that the plan and its part agree, never whose project they are in. That is
why `POST /responses/detach` deleted a plan of somebody else's project given nothing but its two
numbers, which run in sequence.

The check is the same one the three siblings use.

`get` takes a connection now, the way the methods of `Plan` do, because `Tasks#done` and
`Tasks#postpone` call it inside an open transaction, and asking the pool for a second connection
there hangs a pool of one. The two call sites pass the transaction they already hold.

Closes #484
