### PR TITLE
#488: hang the id on the link, not on its title

### DIFF
--- a/test/test_responses.rb
+++ b/test/test_responses.rb
@@ -6,6 +6,7 @@
 require 'rack/test'
 require 'securerandom'
 require_relative 'test__helper'
+
 require_relative '../0rsk'
 require_relative '../objects/plans'
 require_relative '../objects/triples'

--- a/test/test_responses.rb
+++ b/test/test_responses.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require 'rack/test'
+require 'securerandom'
+require_relative 'test__helper'
+require_relative '../0rsk'
+require_relative '../objects/plans'
+require_relative '../objects/triples'
+
+class Rsk::ResponsesTest < TestCase
+  include Rack::Test::Methods
+
+  def app
+    Sinatra::Application
+  end
+
+  def test_renders_the_responses_page
+    login = "u#{SecureRandom.hex(8)}"
+    project = Rsk::Projects.new(test_pgsql, login).add("p#{SecureRandom.hex(8)}")
+    risk = Rsk::Risks.new(test_pgsql, project).add("risk #{SecureRandom.hex(8)}")
+    triple = Rsk::Triples.new(test_pgsql, project).add(
+      Rsk::Causes.new(test_pgsql, project).add("cause #{SecureRandom.hex(8)}"),
+      risk,
+      Rsk::Effects.new(test_pgsql, project).add("effect #{SecureRandom.hex(8)}")
+    )
+    Rsk::Plans.new(test_pgsql, project).add(risk, "plan #{SecureRandom.hex(8)}")
+    set_cookie("glogin=#{login}")
+    set_cookie("0rsk-project=#{project}")
+    ['/plans', '/tasks', "/responses?id=#{triple}"].each do |uri|
+      get(uri)
+      assert_equal(200, last_response.status, "#{uri} fails: #{last_response.body}")
+    end
+  end
+end

--- a/views/plans.haml
+++ b/views/plans.haml
@@ -43,7 +43,7 @@
           %td
             %code= "P#{r[:id]}"
           %td
-            %a{href: iri.cut('/responses'), title: 'View responses'.add(id: r[:triple])}<
+            %a{href: iri.cut('/responses').add(id: r[:triple]), title: 'View responses'}<
               %code= "#{r[:prefix]}#{r[:part]}"
           %td
             &= r[:text]

--- a/views/responses.haml
+++ b/views/responses.haml
@@ -6,7 +6,7 @@
 
 %h2
   Responses to
-  %a{href: iri.cut('/triple'), title: 'New risk triple'.add(id: triple[:id])}
+  %a{href: iri.cut('/triple').add(id: triple[:id]), title: 'New risk triple'}
     = "##{triple[:id]}"
 
 %p

--- a/views/tasks.haml
+++ b/views/tasks.haml
@@ -43,7 +43,7 @@
       %br
       = part('T', t[:id])
       ➜
-      %a{href: iri.cut('/responses'), title: 'View responses'.add(id: t[:triple])}<
+      %a{href: iri.cut('/responses').add(id: t[:triple]), title: 'View responses'}<
         %code= "P#{t[:plan]}"
       ➜
       = part(t[:prefix], t[:part])


### PR DESCRIPTION
The closing parenthesis was in the wrong place, so `add` was called on the title string instead of on the `Iri`. `String` has no `add`, so `/responses` failed on every request and `/plans` and `/tasks` failed as soon as the account had one row. The link also lost its `id`.


Closes #488
