### PR TITLE
#489: point at the project page that exists

### DIFF
--- a/front/front_telegram.rb
+++ b/front/front_telegram.rb
@@ -185,7 +185,7 @@ module Rsk::Telegram
             "\n\n[T#{t[:id]}](https://www.0rsk.com/responses?id=#{t[:triple]})",
             "(#{t[:positive] ? '+' : '-'}#{t[:rank]})",
             Rsk::Markdown.new(t[:text]).to_s,
-            "in [#{Rsk::Markdown.new(t[:title])}](https://www.0rsk.com/projects/#{t[:pid]}):",
+            "in [#{Rsk::Markdown.new(t[:title])}](https://www.0rsk.com/project/#{t[:pid]}):",
             "#{Rsk::Markdown.new(t[:ctext])}; #{Rsk::Markdown.new(t[:rtext])}; #{Rsk::Markdown.new(t[:etext])}",
             "(#{Rsk::Markdown.new(t[:schedule])})"
           ].join(' ')

--- a/test/test_project_link.rb
+++ b/test/test_project_link.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require 'securerandom'
+require_relative 'test__helper'
+require_relative '../0rsk'
+
+class Rsk::ProjectLinkTest < TestCase
+  def test_links_to_the_project_page
+    listing = Object.new.extend(Rsk::Telegram).listing(
+      [
+        {
+          id: 42, triple: 7, positive: true, rank: 3, text: 'Do it',
+          title: 'Project', pid: 5, ctext: 'Cause', rtext: 'Risk',
+          etext: 'Effect', schedule: 'weekly'
+        }
+      ]
+    ).flatten.join(' ')
+    assert_includes(listing, 'https://www.0rsk.com/project/5', listing)
+  end
+end

--- a/test/test_project_link.rb
+++ b/test/test_project_link.rb
@@ -5,6 +5,7 @@
 
 require 'securerandom'
 require_relative 'test__helper'
+
 require_relative '../0rsk'
 
 class Rsk::ProjectLinkTest < TestCase

--- a/views/tasks.haml
+++ b/views/tasks.haml
@@ -58,7 +58,7 @@
         &= t[:text]
       %br
       %span.small
-        %a.item{href: iri.cut('/projects').append(t[:pid]), title: 'View project'}<
+        %a.item{href: iri.cut('/project').append(t[:pid]), title: 'View project'}<
           &= t[:title]
         %span.item<
           &= t[:schedule]


### PR DESCRIPTION
Both links pointed at `/projects/{id}`, which is not a route. The project page is `/project/{id}`, singular, so clicking a project name under a task, or the project link in a Telegram listing, gave a 404.


Closes #489
