### PR TITLE
#509: point eslint at the directory the scripts live in

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -28,7 +28,7 @@ end
 
 require 'eslintrb/eslinttask'
 Eslintrb::EslintTask.new(:eslint) do |t|
-  t.pattern = 'js/**/*.js'
+  t.pattern = 'public/js/**/*.js'
   t.options = :defaults
 end
 


### PR DESCRIPTION
The pattern was `js/**/*.js`, and there is no `js/` directory, so the task matched nothing:

```
old pattern js/**/*.js        -> []
new pattern public/js/**/*.js -> ["public/js/responses.js", "public/js/triple.js"]
```

`Eslintrb::EslintTask` wraps its body in `unless js_file_list.empty?`, so the task did nothing and reported success. Both scripts have been unlinted since #194 moved them into `public/js/`.

Closes #509
