### PR TITLE
#514: say plainly that the plan is already there

### DIFF
--- a/objects/plans.rb
+++ b/objects/plans.rb
@@ -27,6 +27,8 @@ class Rsk::Plans
       t.exec('INSERT INTO plan (id, part) VALUES ($1, $2)', [id, part])
       id
     end
+  rescue PG::UniqueViolation
+    raise(Rsk::Urror, "Plan \"#{text}\" already exists in this project")
   end
 
   def get(id, part, con: nil)

--- a/test/test_plans_duplicate.rb
+++ b/test/test_plans_duplicate.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require 'securerandom'
+require_relative 'test__helper'
+
+require_relative '../objects/plans'
+
+class Rsk::PlansDuplicateTest < TestCase
+  def test_refuses_a_plan_that_is_already_there
+    project = test_project
+    part = test_risk(project: project)
+    plans = Rsk::Plans.new(test_pgsql, project)
+    text = "plan #{SecureRandom.hex(8)}"
+    plans.add(part, text)
+    e = assert_raises(Rsk::Urror) { plans.add(part, text) }
+    assert_includes(e.message, text, e.message)
+  end
+end


### PR DESCRIPTION
`Causes#add`, `Risks#add` and `Effects#add` all turn a duplicate text into a `Rsk::Urror`. `Plans#add` did not, so `part`'s `UNIQUE(project, text)` reached the user as a raw `PG::UniqueViolation`, and the error handler rendered the 503 page with a backtrace instead of a message.

Closes #514
