### PR TITLE
#532: refuse a detach that matches no plan

### DIFF
--- a/objects/plan.rb
+++ b/objects/plan.rb
@@ -56,7 +56,9 @@ class Rsk::Plan
     if con.exec('SELECT * FROM part WHERE id = $1 AND project = $2', [@part, project]).empty?
       raise(Rsk::Urror, "##{@id} is not in your project ##{project}")
     end
-    con.exec('DELETE FROM plan WHERE id = $1 AND part = $2', [@id, @part])
+    if con.exec('DELETE FROM plan WHERE id = $1 AND part = $2 RETURNING id', [@id, @part]).empty?
+      raise(Rsk::Urror, "Plan ##{@id} is not attached to the part ##{@part}")
+    end
     return unless con.exec('SELECT * FROM plan WHERE id = $1', [@id]).empty?
     con.exec('DELETE FROM part WHERE id = $1', [@id])
   end

--- a/test/test_plan_detach.rb
+++ b/test/test_plan_detach.rb
@@ -11,10 +11,9 @@ require_relative '../objects/plans'
 class Rsk::PlanDetachTest < TestCase
   def test_refuses_a_part_the_plan_does_not_hang_on
     project = test_project
-    risk = test_risk(project: project)
     cause = test_cause(project: project)
     plans = Rsk::Plans.new(test_pgsql, project)
-    id = plans.add(risk, "plan #{SecureRandom.hex(8)}")
+    id = plans.add(test_risk(project: project), "plan #{SecureRandom.hex(8)}")
     assert_raises(Rsk::Urror) { plans.get(id, cause).detach }
     assert_equal(1, plans.count(query: ''), 'the plan must still be there')
   end
@@ -23,8 +22,7 @@ class Rsk::PlanDetachTest < TestCase
     project = test_project
     risk = test_risk(project: project)
     plans = Rsk::Plans.new(test_pgsql, project)
-    id = plans.add(risk, "plan #{SecureRandom.hex(8)}")
-    plans.get(id, risk).detach
+    plans.get(plans.add(risk, "plan #{SecureRandom.hex(8)}"), risk).detach
     assert_equal(0, plans.count(query: ''), 'the plan must be gone')
   end
 end

--- a/test/test_plan_detach.rb
+++ b/test/test_plan_detach.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require 'securerandom'
+require_relative 'test__helper'
+
+require_relative '../objects/plans'
+
+class Rsk::PlanDetachTest < TestCase
+  def test_refuses_a_part_the_plan_does_not_hang_on
+    project = test_project
+    risk = test_risk(project: project)
+    cause = test_cause(project: project)
+    plans = Rsk::Plans.new(test_pgsql, project)
+    id = plans.add(risk, "plan #{SecureRandom.hex(8)}")
+    assert_raises(Rsk::Urror) { plans.get(id, cause).detach }
+    assert_equal(1, plans.count(query: ''), 'the plan must still be there')
+  end
+
+  def test_detaches_the_plan_it_hangs_on
+    project = test_project
+    risk = test_risk(project: project)
+    plans = Rsk::Plans.new(test_pgsql, project)
+    id = plans.add(risk, "plan #{SecureRandom.hex(8)}")
+    plans.get(id, risk).detach
+    assert_equal(0, plans.count(query: ''), 'the plan must be gone')
+  end
+end


### PR DESCRIPTION
The delete never checked how many rows it matched, and the guard above it only checks that the part is in the project, not that the plan hangs on that part. So a request naming the right plan and the wrong part deleted nothing and still flashed "plan detached". A stale form was enough to hit it.

The delete now returns what it removed and says so when the pair does not go together.

Closes #532
