### PR TITLE
#524: count the message the way Telegram counts it

### DIFF
--- a/objects/trimmed.rb
+++ b/objects/trimmed.rb
@@ -13,9 +13,22 @@ class Rsk::Trimmed
 
   def to_s
     text = @text.to_s
-    return text if text.length <= @max
-    head = text[0...@max]
+    return text if units(text) <= @max
+    head = +''
+    room = @max
+    text.each_char do |c|
+      width = c.ord > 0xFFFF ? 2 : 1
+      break if width > room
+      head << c
+      room -= width
+    end
     stop = head.rindex("\n")
     "#{stop.nil? ? head : head[0...stop]}..."
+  end
+
+  private
+
+  def units(text)
+    text.each_char.sum { |c| c.ord > 0xFFFF ? 2 : 1 }
   end
 end

--- a/test/test_trimmed.rb
+++ b/test/test_trimmed.rb
@@ -17,8 +17,7 @@ class Rsk::TrimmedTest < TestCase
   end
 
   def test_counts_an_emoji_the_way_telegram_counts_it
-    text = '🔥' * 4480
-    trimmed = Rsk::Trimmed.new(text, 4000).to_s
+    trimmed = Rsk::Trimmed.new('🔥' * 4480, 4000).to_s
     assert_operator(units(trimmed), :<=, 4096, "#{units(trimmed)} units is over the API limit")
   end
 

--- a/test/test_trimmed.rb
+++ b/test/test_trimmed.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'test__helper'
+
+require_relative '../objects/trimmed'
+
+class Rsk::TrimmedTest < TestCase
+  def test_keeps_a_short_text_as_it_is
+    assert_equal('hello', Rsk::Trimmed.new('hello', 4000).to_s)
+  end
+
+  def test_cuts_at_the_last_line_break
+    assert_equal("a\nb...", Rsk::Trimmed.new("a\nb\ncdefgh", 6).to_s)
+  end
+
+  def test_counts_an_emoji_the_way_telegram_counts_it
+    text = '🔥' * 4480
+    trimmed = Rsk::Trimmed.new(text, 4000).to_s
+    assert_operator(units(trimmed), :<=, 4096, "#{units(trimmed)} units is over the API limit")
+  end
+
+  private
+
+  def units(text)
+    text.each_char.sum { |c| c.ord > 0xFFFF ? 2 : 1 }
+  end
+end


### PR DESCRIPTION
`Rsk::Trimmed` counted Ruby characters while Telegram counts UTF-16 code units, and every emoji is two of them. The 4000 that `telepost` passes was chosen to stay under the API limit of 4096, but a trimmed message of 4000 emoji is 8000 units and the API refuses it.

```
before: 4480 emoji -> 4003 chars -> 8003 units
after:  4480 emoji -> 2000 chars -> 4000 units
```

Closes #524
