### PR TITLE
#533: refuse a project title that the column cannot hold

### DIFF
--- a/objects/projects.rb
+++ b/objects/projects.rb
@@ -7,14 +7,20 @@ require_relative 'rsk'
 require_relative 'urror'
 
 class Rsk::Projects
+  MAX = 64
+
   def initialize(pgsql, login)
     @pgsql = pgsql
     @login = login
   end
 
   def add(title)
+    text = title.to_s.strip
+    raise(Rsk::Urror, 'The title of a project can\'t be empty') if text.empty?
+    raise(Rsk::Urror, "The title is longer than #{Rsk::Projects::MAX} characters: #{text.length}") if
+      text.length > Rsk::Projects::MAX
     Integer(
-      @pgsql.exec('INSERT INTO project (login, title) VALUES ($1, $2) RETURNING id', [@login, title])[0]['id'],
+      @pgsql.exec('INSERT INTO project (login, title) VALUES ($1, $2) RETURNING id', [@login, text])[0]['id'],
       10
     )
   rescue PG::UniqueViolation

--- a/test/test_projects_title.rb
+++ b/test/test_projects_title.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require 'securerandom'
+require_relative 'test__helper'
+
+require_relative '../objects/projects'
+
+class Rsk::ProjectsTitleTest < TestCase
+  def test_refuses_an_empty_title
+    projects = Rsk::Projects.new(test_pgsql, "u#{SecureRandom.hex(8)}")
+    ['', '   ', nil].each do |bad|
+      assert_raises(Rsk::Urror, "title #{bad.inspect} must be refused") { projects.add(bad) }
+    end
+  end
+
+  def test_refuses_a_title_longer_than_the_column
+    projects = Rsk::Projects.new(test_pgsql, "u#{SecureRandom.hex(8)}")
+    assert_raises(Rsk::Urror) { projects.add('t' * 200) }
+  end
+
+  def test_trims_the_title
+    projects = Rsk::Projects.new(test_pgsql, "u#{SecureRandom.hex(8)}")
+    title = "p#{SecureRandom.hex(8)}"
+    projects.add("  #{title}  ")
+    assert_equal(title, projects.fetch[0][:title])
+  end
+end


### PR DESCRIPTION
The title went straight into the insert. An empty one satisfied `NOT NULL`, so a nameless project appeared on `/projects` and in the Telegram listings with no way to rename it, and a title over 64 characters or a missing one raised out of PostgreSQL and rendered a backtrace.

It is trimmed and checked now, so all three cases give a message.

Closes #533
