### PR TITLE
#491: put the Delete button inside the form it submits

### DIFF
--- a/test/test_projects_page.rb
+++ b/test/test_projects_page.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require 'nokogiri'
+require 'rack/test'
+require 'securerandom'
+require_relative 'test__helper'
+
+require_relative '../0rsk'
+
+class Rsk::ProjectsPageTest < TestCase
+  include Rack::Test::Methods
+
+  def app
+    Sinatra::Application
+  end
+
+  def test_puts_the_delete_button_inside_its_form
+    login = "u#{SecureRandom.hex(8)}"
+    pid = Rsk::Projects.new(test_pgsql, login).add("p#{SecureRandom.hex(8)}")
+    set_cookie("glogin=#{login}")
+    set_cookie("0rsk-project=#{pid}")
+    get('/projects')
+    assert_equal(200, last_response.status, last_response.body)
+    html = Nokogiri::HTML.parse(last_response.body)
+    form = html.xpath("//form[contains(@action, '/projects/delete')]").first
+    refute_nil(form, last_response.body)
+    refute_empty(form.xpath('.//button'), "the Delete button must be inside its form: #{last_response.body}")
+  end
+end

--- a/test/test_projects_page.rb
+++ b/test/test_projects_page.rb
@@ -19,13 +19,11 @@ class Rsk::ProjectsPageTest < TestCase
 
   def test_puts_the_delete_button_inside_its_form
     login = "u#{SecureRandom.hex(8)}"
-    pid = Rsk::Projects.new(test_pgsql, login).add("p#{SecureRandom.hex(8)}")
     set_cookie("glogin=#{login}")
-    set_cookie("0rsk-project=#{pid}")
+    set_cookie("0rsk-project=#{Rsk::Projects.new(test_pgsql, login).add("p#{SecureRandom.hex(8)}")}")
     get('/projects')
     assert_equal(200, last_response.status, last_response.body)
-    html = Nokogiri::HTML.parse(last_response.body)
-    form = html.xpath("//form[contains(@action, '/projects/delete')]").first
+    form = Nokogiri::HTML.parse(last_response.body).xpath("//form[contains(@action,'/projects/delete')]").first
     refute_nil(form, last_response.body)
     refute_empty(form.xpath('.//button'), "the Delete button must be inside its form: #{last_response.body}")
   end

--- a/views/projects.haml
+++ b/views/projects.haml
@@ -25,5 +25,5 @@
       %br
       %span.small
         %form{action: iri.cut('/projects/delete').add(id: p[:id]), method: 'POST', style: 'display:inline', onsubmit: "return confirm('Are sure you want to delete it?')"}
-  %button{type: 'submit', title: 'Delete project', style: 'background:none;border:none;padding:0;color:inherit;font:inherit;cursor:pointer'}
-    Delete
+          %button{type: 'submit', title: 'Delete project', style: 'background:none;border:none;padding:0;color:inherit;font:inherit;cursor:pointer'}
+            Delete


### PR DESCRIPTION
The button was indented at the same level as the `projects.each` loop, so Haml closed the form and the loop before it. The page rendered an empty `<form>` per project and one stray button after the loop, which belongs to no form and does nothing when clicked, so `POST /projects/delete` could not be reached from the interface and the confirmation never fired.

Closes #491
