### PR TITLE
#492: select the value the triple has, not the default too

### DIFF
--- a/test/test_triple_page.rb
+++ b/test/test_triple_page.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require 'nokogiri'
+require 'rack/test'
+require 'securerandom'
+require_relative 'test__helper'
+
+require_relative '../0rsk'
+require_relative '../objects/triples'
+
+class Rsk::TriplePageTest < TestCase
+  include Rack::Test::Methods
+
+  def app
+    Sinatra::Application
+  end
+
+  def test_shows_the_probability_the_triple_has
+    login = "u#{SecureRandom.hex(8)}"
+    project = Rsk::Projects.new(test_pgsql, login).add("p#{SecureRandom.hex(8)}")
+    risk = Rsk::Risks.new(test_pgsql, project).add("risk #{SecureRandom.hex(8)}")
+    Rsk::Risks.new(test_pgsql, project).get(risk).weigh(8)
+    tid = Rsk::Triples.new(test_pgsql, project).add(
+      Rsk::Causes.new(test_pgsql, project).add("cause #{SecureRandom.hex(8)}"),
+      risk,
+      Rsk::Effects.new(test_pgsql, project).add("effect #{SecureRandom.hex(8)}")
+    )
+    set_cookie("glogin=#{login}")
+    set_cookie("0rsk-project=#{project}")
+    get("/triple?id=#{tid}")
+    assert_equal(200, last_response.status, last_response.body)
+    picked = Nokogiri::HTML.parse(last_response.body)
+      .xpath("//select[@id='probability']/option[@selected]").map { |o| o['value'] }
+    assert_equal(['8'], picked, "exactly one option must be selected: #{last_response.body}")
+  end
+end

--- a/test/test_triple_page.rb
+++ b/test/test_triple_page.rb
@@ -23,17 +23,21 @@ class Rsk::TriplePageTest < TestCase
     project = Rsk::Projects.new(test_pgsql, login).add("p#{SecureRandom.hex(8)}")
     risk = Rsk::Risks.new(test_pgsql, project).add("risk #{SecureRandom.hex(8)}")
     Rsk::Risks.new(test_pgsql, project).get(risk).weigh(8)
-    tid = Rsk::Triples.new(test_pgsql, project).add(
-      Rsk::Causes.new(test_pgsql, project).add("cause #{SecureRandom.hex(8)}"),
-      risk,
-      Rsk::Effects.new(test_pgsql, project).add("effect #{SecureRandom.hex(8)}")
-    )
     set_cookie("glogin=#{login}")
     set_cookie("0rsk-project=#{project}")
-    get("/triple?id=#{tid}")
+    get(
+      "/triple?id=#{Rsk::Triples.new(test_pgsql, project).add(
+        Rsk::Causes.new(test_pgsql, project).add("cause #{SecureRandom.hex(8)}"),
+        risk,
+        Rsk::Effects.new(test_pgsql, project).add("effect #{SecureRandom.hex(8)}")
+      )}"
+    )
     assert_equal(200, last_response.status, last_response.body)
-    picked = Nokogiri::HTML.parse(last_response.body)
-      .xpath("//select[@id='probability']/option[@selected]").map { |o| o['value'] }
-    assert_equal(['8'], picked, "exactly one option must be selected: #{last_response.body}")
+    html = Nokogiri::HTML.parse(last_response.body)
+    assert_equal(
+      ['8'],
+      html.xpath("//select[@id='probability']/option[@selected]").map { |o| o['value'] },
+      "exactly one option must be selected: #{last_response.body}"
+    )
   end
 end

--- a/views/triple.haml
+++ b/views/triple.haml
@@ -59,7 +59,7 @@
   %br
   %select#probability{name: 'probability', tabindex: 4}
     - {'Definitely' => 9, 'Extremely high' => 8, 'High' => 6, 'Average' => 5, 'Low' => 4, 'Very low' => 2, 'Unlikely' => 1}.each do |k, v|
-      %option{value: v, selected: defined?(triple) && triple[:probability] == v || v == 5}= "#{k} (#{v})"
+      %option{value: v, selected: defined?(triple) ? triple[:probability] == v : v == 5}= "#{k} (#{v})"
   %br
   %label
     Effect:
@@ -78,9 +78,9 @@
   %br
   %select#impact{name: 'impact', tabindex: 7}
     - {'Fatal' => 9, 'Catastrophic' => 8, 'Serious' => 6, 'Average' => 5, 'Moderate' => 4, 'Minor' => 2, 'Unnoticeable' => 1}.each do |k, v|
-      %option{value: v, selected: defined?(triple) && triple[:impact] == v || v == 5, type: 'negative', hidden: defined?(triple) && triple[:positive]}= "#{k} (#{v})"
+      %option{value: v, selected: defined?(triple) ? !triple[:positive] && triple[:impact] == v : v == 5, type: 'negative', hidden: defined?(triple) && triple[:positive]}= "#{k} (#{v})"
     - {'Fantastic' => 9, 'Awesome' => 8, 'Very good' => 6, 'Average' => 5, 'Good to have' => 4, 'Minor' => 2, 'Unnoticeable' => 1}.each do |k, v|
-      %option{value: v, selected: defined?(triple) && triple[:impact] == v, type: 'positive', hidden: !defined?(triple) || !triple[:positive]}= "#{k} (#{v})"
+      %option{value: v, selected: defined?(triple) && triple[:positive] && triple[:impact] == v, type: 'positive', hidden: !defined?(triple) || !triple[:positive]}= "#{k} (#{v})"
   - if defined?(triple) && triple[:positive]
     %img#marker.up{alt: 'up'}
   - else


### PR DESCRIPTION
`&&` binds tighter than `||`, so `defined?(triple) && triple[:probability] == v || v == 5` meant "this value, or 5 regardless". Editing a triple whose probability is 9, 8 or 6 marked two options selected, and a single-select keeps the last one, which is `Average (5)`.

That is not only a display slip: submitting the form sends 5 back and `risks.get(rid).weigh(5)` overwrites the stored probability. The same mistake was on the impact list, where the positive-scale option was also marked selected regardless of polarity, so a negative triple with impact 8 showed three selected options and read "Awesome (8)" instead of "Catastrophic (8)".

Closes #492
