### PR TITLE
#506: force the add and arm the cleanup before it can fail

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -7,11 +7,13 @@ set -e
 cd "$(dirname "$0")"
 bundle update
 # rake
+committed=0
+trap 'if [ "${committed}" -eq 1 ]; then git reset HEAD~1; fi; rm -f config.yml; git checkout -- .gitignore' EXIT
 sed -i -s 's|Gemfile.lock||g' .gitignore
 cp /code/home/assets/0rsk/config.yml .
-git add config.yml
+git add -f config.yml
 git add Gemfile.lock
 git add .gitignore
 git commit -m 'config.yml for heroku'
-trap 'git reset HEAD~1 && rm config.yml && git checkout -- .gitignore' EXIT
+committed=1
 git push heroku master -f


### PR DESCRIPTION
`config.yml` is in `.gitignore`, so `git add config.yml` refused it and, under `set -e`, the script died right there:

```
The following paths are ignored by one of your .gitignore files:
config.yml
hint: Use -f if you really want to add them.
```

That happened before the cleanup trap was installed, so nothing deployed and the production `config.yml`, with the OAuth secret, the Sentry DSN and the bot token in it, was left untracked in the working copy.

The add is forced now, and the trap is armed before the first step that can fail. It carries a flag so that `git reset HEAD~1` only runs when a commit was actually made, otherwise the cleanup would throw away a real commit.

Closes #506
