### PR TITLE
#537: prune one client, and do not record a rejected request

### DIFF
--- a/objects/limits.rb
+++ b/objects/limits.rb
@@ -6,6 +6,8 @@
 require_relative 'rsk'
 
 class Rsk::Limits
+  SWEEP = 1024
+
   def initialize(max: 10, period: 60)
     @max = max
     @period = period
@@ -15,11 +17,19 @@ class Rsk::Limits
 
   def over?(client, now: Time.now.to_i)
     @mutex.synchronize do
-      @seen.each_value { |hits| hits.reject! { |t| t < now - @period } }
-      @seen.reject! { |_, hits| hits.empty? }
+      sweep(now) if @seen.size > Rsk::Limits::SWEEP
       hits = (@seen[client] ||= [])
-      hits << now
-      hits.size > @max
+      hits.reject! { |t| t < now - @period }
+      over = hits.size >= @max
+      hits << now unless over
+      over
     end
+  end
+
+  private
+
+  def sweep(now)
+    @seen.each_value { |hits| hits.reject! { |t| t < now - @period } }
+    @seen.reject! { |_, hits| hits.empty? }
   end
 end

--- a/test/test_limits.rb
+++ b/test/test_limits.rb
@@ -23,6 +23,17 @@ class Rsk::LimitsTest < TestCase
     refute(limits.over?('1.1.1.1', now: now + 61))
   end
 
+  def test_does_not_let_a_rejected_request_extend_the_block
+    limits = Rsk::Limits.new(max: 2, period: 60)
+    now = Time.now.to_i
+    2.times { limits.over?('1.1.1.1', now: now) }
+    5.times { assert(limits.over?('1.1.1.1', now: now + 30), 'must be over the limit') }
+    refute(
+      limits.over?('1.1.1.1', now: now + 61),
+      'the requests that were refused must not keep the client blocked'
+    )
+  end
+
   def test_survives_concurrent_hits
     limits = Rsk::Limits.new(max: 1_000_000)
     Array.new(8) do

--- a/test/test_limits.rb
+++ b/test/test_limits.rb
@@ -23,7 +23,7 @@ class Rsk::LimitsTest < TestCase
     refute(limits.over?('1.1.1.1', now: now + 61))
   end
 
-  def test_does_not_let_a_rejected_request_extend_the_block
+  def test_forgets_a_refused_request
     limits = Rsk::Limits.new(max: 2, period: 60)
     now = Time.now.to_i
     2.times { limits.over?('1.1.1.1', now: now) }

--- a/test/test_limits.rb
+++ b/test/test_limits.rb
@@ -28,10 +28,7 @@ class Rsk::LimitsTest < TestCase
     now = Time.now.to_i
     2.times { limits.over?('1.1.1.1', now: now) }
     5.times { assert(limits.over?('1.1.1.1', now: now + 30), 'must be over the limit') }
-    refute(
-      limits.over?('1.1.1.1', now: now + 61),
-      'the requests that were refused must not keep the client blocked'
-    )
+    refute(limits.over?('1.1.1.1', now: now + 61), 'a refused request must not keep the client blocked')
   end
 
   def test_survives_concurrent_hits


### PR DESCRIPTION
Three things, all in `over?`, which runs on every POST:

It swept the whole hash on every call, so the cost grew with the number of clients seen in the window, and because the mutex is process-wide that cost serialised all POST traffic. Measured: 92us at 100 clients, 3372us at 10000. Now it prunes only the caller's own entry, and sweeps the rest only when the hash passes `SWEEP`.

It recorded a request even when it was refusing it, so a client being actively blocked kept extending its own block. One IP sending 20000 requests in a 60s window stored 20000 timestamps against a limit of 10. The new test covers exactly that: after the limit is reached, further refused requests must not keep the client blocked once the window has passed.

Pruning only happened when a new request arrived, so after traffic stopped the whole hash was retained. The sweep now clears empty clients out.

The existing three tests pass unchanged.

Closes #537
