### PR TITLE
#522: offer the next page only when there is one

### DIFF
--- a/test/test_paging_view.rb
+++ b/test/test_paging_view.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require 'nokogiri'
+require 'rack/test'
+require 'securerandom'
+require_relative 'test__helper'
+
+require_relative '../0rsk'
+
+class Rsk::PagingViewTest < TestCase
+  include Rack::Test::Methods
+
+  def app
+    Sinatra::Application
+  end
+
+  def test_hides_the_next_link_on_the_last_page
+    login = "u#{SecureRandom.hex(8)}"
+    project = Rsk::Projects.new(test_pgsql, login).add("p#{SecureRandom.hex(8)}")
+    causes = Rsk::Causes.new(test_pgsql, project)
+    4.times { causes.add("cause #{SecureRandom.hex(8)}") }
+    set_cookie("glogin=#{login}")
+    set_cookie("0rsk-project=#{project}")
+    get('/causes?limit=2&offset=2')
+    assert_equal(200, last_response.status, last_response.body)
+    assert_empty(nexts, "the last page must offer no Next: #{last_response.body}")
+    get('/causes?limit=2&offset=0')
+    refute_empty(nexts, "the first page must offer Next: #{last_response.body}")
+  end
+
+  private
+
+  def nexts
+    Nokogiri::HTML.parse(last_response.body).xpath("//a[normalize-space(text())='Next']")
+  end
+end

--- a/views/_paging.haml
+++ b/views/_paging.haml
@@ -11,5 +11,5 @@
     - (0..((total - 1) / limit).floor).each do |p|
       - next if p < current - 5 || p > current + 5
       %a.item{href: iri.over(offset: p * limit), style: p == current ? 'font-weight:bold' : '', title: "Page #{p + 1}"}= p + 1
-    - if count >= limit
+    - if offset + limit < total
       %a.item{href: iri.over(offset: offset + limit), title: "Next page"} Next


### PR DESCRIPTION
The Next link appeared whenever the current page was full, without checking that anything came after it. With 50 causes and a limit of 25, page two was full, so Next was shown, and it led to a page with no rows: "No causes as of yet." on a project that has 50 of them, and no Previous link to get back, because the list templates render the paging block only in the non-empty branch.

Next is now offered only when `offset + limit < total`, so that path is closed. A page reached by hand-editing the offset past the end still shows no paging controls; that is the templates' side and is not touched here.

Closes #522
