### PR TITLE
#519: expect a text in the form, not merely something

### DIFF
--- a/front/front_triple.rb
+++ b/front/front_triple.rb
@@ -88,7 +88,7 @@ end
 
 post '/triple/save' do
   %i[ctext rtext etext cid rid eid probability impact].each do |name|
-    raise(Rsk::Urror, "The #{name} is missing in the form") if params[name].nil?
+    raise(Rsk::Urror, "The #{name} is missing in the form") unless params[name].is_a?(String)
   end
   ctext = params[:ctext].strip
   rtext = params[:rtext].strip

--- a/test/test_triple_save.rb
+++ b/test/test_triple_save.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require 'rack/test'
+require 'securerandom'
+require_relative 'test__helper'
+
+require_relative '../0rsk'
+
+class Rsk::TripleSaveTest < TestCase
+  include Rack::Test::Methods
+
+  def app
+    Sinatra::Application
+  end
+
+  def test_refuses_a_form_field_that_is_not_a_text
+    login = "u#{SecureRandom.hex(8)}"
+    set_cookie("glogin=#{login}")
+    set_cookie("0rsk-project=#{Rsk::Projects.new(test_pgsql, login).add("p#{SecureRandom.hex(8)}")}")
+    post('/triple/save', 'ctext[]=x&rtext=r&etext=e&cid=&rid=&eid=&probability=1&impact=1')
+    assert_equal(302, last_response.status, last_response.body)
+    refute_includes(last_response.body, '<pre', last_response.body)
+  end
+end


### PR DESCRIPTION
The guard exists to turn a malformed form into a readable message, but it only checked for `nil`. Rack parses `ctext[]=x` into an `Array`, which is not `nil`, so the guard passed and `Array#strip` raised `NoMethodError` a line later, producing exactly the 503 page with a backtrace that the guard was written to prevent. With `cid[]=1` it went further: `Array#empty?` is legal, so an `Array` reached PostgreSQL as a bind parameter.

It now requires a `String`, so anything else gives the friendly `Rsk::Urror`.

Closes #519
