### PR TITLE
#523: count the risks and effects, not the triples

### DIFF
--- a/objects/causes.rb
+++ b/objects/causes.rb
@@ -74,7 +74,7 @@ class Rsk::Causes
       [
         'SELECT cause.*, part.text,',
         '  SUM(risk.probability * effect.impact) / COUNT(risk.id) AS rank,',
-        '  COUNT(risk.id) AS risks',
+        '  COUNT(DISTINCT risk.id) AS risks',
         'FROM cause',
         'JOIN part ON part.id = cause.id',
         'LEFT JOIN triple ON triple.cause = cause.id',

--- a/objects/effects.rb
+++ b/objects/effects.rb
@@ -66,7 +66,7 @@ class Rsk::Effects
         'SELECT effect.*, part.text AS text,',
         '  SUM(risk.probability) AS probability,',
         '  effect.impact * SUM(risk.probability) / COUNT(risk.id) AS rank,',
-        '  COUNT(risk.id) AS risks',
+        '  COUNT(DISTINCT risk.id) AS risks',
         'FROM effect',
         'JOIN part ON part.id = effect.id',
         'LEFT JOIN triple ON triple.effect = effect.id',

--- a/objects/risks.rb
+++ b/objects/risks.rb
@@ -62,7 +62,7 @@ class Rsk::Risks
         'SELECT risk.*, part.text AS text,',
         '  SUM(effect.impact) AS impact,',
         '  risk.probability * SUM(effect.impact) / COUNT(effect.id) AS rank,',
-        '  COUNT(effect.id) AS effects',
+        '  COUNT(DISTINCT effect.id) AS effects',
         'FROM risk',
         'JOIN part ON part.id = risk.id',
         'LEFT JOIN triple ON triple.risk = risk.id',

--- a/test/test_causes_count.rb
+++ b/test/test_causes_count.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require 'securerandom'
+require_relative 'test__helper'
+
+require_relative '../objects/causes'
+require_relative '../objects/triples'
+
+class Rsk::CausesCountTest < TestCase
+  def test_counts_one_risk_once_whatever_the_triples
+    project = test_project
+    cause = test_cause(project: project)
+    risk = test_risk(project: project)
+    triples = Rsk::Triples.new(test_pgsql, project)
+    3.times { triples.add(cause, risk, test_effect(project: project)) }
+    assert_equal(
+      1,
+      Rsk::Causes.new(test_pgsql, project).fetch[0][:risks],
+      'one risk through three triples is still one risk'
+    )
+  end
+end


### PR DESCRIPTION
`COUNT(risk.id)` counts the rows the `LEFT JOIN triple` produced, so a cause tied to one risk through three triples reported 3. The column is headed "Risks" and is exported as `risks` in `causes.csv`, so the number did not mean what it says. Same for the "Effects" column on `/risks` and the "Risks" column on `/effects`.

The displayed counts are `COUNT(DISTINCT ...)` now. The rank average keeps its own divisor, which is deliberate there.

Closes #523
