### PR TITLE
#495: set the polarity before the impact it resets

### DIFF
--- a/public/js/triple.js
+++ b/public/js/triple.js
@@ -25,7 +25,7 @@ function auto(kind, uri) {
       });
     },
     select: function(event, ui) {
-      $.each(ui.item.fields, function(field, v) {
+      var apply = function(field, v) {
         var $field = $("#" + field);
         if (typeof v === "boolean") {
           $field.prop("checked", v);
@@ -34,6 +34,16 @@ function auto(kind, uri) {
         }
         $field.trigger("change");
         $("#" + kind + "_detach").show().removeClass("red");
+      };
+      $.each(ui.item.fields, function(field, v) {
+        if (typeof v === "boolean") {
+          apply(field, v);
+        }
+      });
+      $.each(ui.item.fields, function(field, v) {
+        if (typeof v !== "boolean") {
+          apply(field, v);
+        }
       });
     },
     close: function() {


### PR DESCRIPTION
`/effects.json` returns its fields as `eid`, `impact`, `positive`, and the handler walked them in that order, firing `change` on each. So it wrote the real impact, then wrote `positive` and fired its handler, which ends both of its branches with `$('#impact').val(5)`. The impact that had just been filled in was thrown away.

Picking an existing effect out of the autocomplete therefore always showed "Average (5)", and submitting called `effects.get(eid).weigh(5)`, overwriting the stored impact of an effect shared by every triple that uses it.

The polarity is applied first now, so the impact is written after the reset rather than before it, whatever order the JSON happens to carry.

There is no browser test suite in this repository (#202), so this is not covered by a test.

Closes #495
