### PR TITLE
#499: forget the plans that hang on a part being removed

### DIFF
--- a/objects/triples.rb
+++ b/objects/triples.rb
@@ -45,15 +45,9 @@ class Rsk::Triples
         raise(Rsk::Urror, "Triple ##{id} is not in your project ##{@project}")
       end
       t.exec('DELETE FROM triple WHERE id = $1', [id])
-      if t.exec('SELECT * FROM triple WHERE cause = $1', [triple[:cid]]).empty?
-        t.exec('DELETE FROM part WHERE id = $1', [triple[:cid]])
-      end
-      if t.exec('SELECT * FROM triple WHERE risk = $1', [triple[:rid]]).empty?
-        t.exec('DELETE FROM part WHERE id = $1', [triple[:rid]])
-      end
-      if t.exec('SELECT * FROM triple WHERE effect = $1', [triple[:eid]]).empty?
-        t.exec('DELETE FROM part WHERE id = $1', [triple[:eid]])
-      end
+      forget(t, triple[:cid]) if t.exec('SELECT * FROM triple WHERE cause = $1', [triple[:cid]]).empty?
+      forget(t, triple[:rid]) if t.exec('SELECT * FROM triple WHERE risk = $1', [triple[:rid]]).empty?
+      forget(t, triple[:eid]) if t.exec('SELECT * FROM triple WHERE effect = $1', [triple[:eid]]).empty?
     end
   end
 
@@ -84,6 +78,11 @@ class Rsk::Triples
   end
 
   private
+
+  def forget(con, part)
+    con.exec('DELETE FROM part WHERE id IN (SELECT id FROM plan WHERE part = $1)', [part])
+    con.exec('DELETE FROM part WHERE id = $1', [part])
+  end
 
   def query(id, query)
     where = []

--- a/test/test_triples_delete.rb
+++ b/test/test_triples_delete.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require 'json'
+require 'securerandom'
+require_relative 'test__helper'
+
+require_relative '../objects/plans'
+require_relative '../objects/triples'
+
+class Rsk::TriplesDeleteTest < TestCase
+  def test_leaves_no_plan_behind
+    project = test_project
+    risk = test_risk(project: project)
+    triples = Rsk::Triples.new(test_pgsql, project)
+    plans = Rsk::Plans.new(test_pgsql, project)
+    text = "plan #{SecureRandom.hex(8)}"
+    plans.add(risk, text)
+    triples.delete(triples.add(test_cause(project: project), risk, test_effect(project: project)))
+    assert_equal(0, triples.count, 'the triple must be gone')
+    assert_equal(0, plans.count(query: ''), 'the plan must be gone')
+    plans.add(test_risk(project: project), text)
+  end
+end


### PR DESCRIPTION
When the last triple referencing a part went away, the part was deleted directly. `plan.part` and `plan.id` both cascade, so the `plan` row went with it, but the `part` row of type `Plan` that was the plan's own identity stayed behind.

Nothing could see that row afterwards, because every query inner-joins `plan`, yet it still held `UNIQUE(project, text)`, so writing a plan with the same wording again failed with a raw `PG::UniqueViolation`. If a task had already been created for that plan, its `task` row survived too, pointing at a part whose plan was gone, invisible in `/tasks` and uncounted by the `THRESHOLD` check.

The three identical blocks now go through one `forget`, which removes the plan parts first and then the part itself.

The test attaches a plan, deletes the triple, and adds a plan with the same text again. On master it fails with exactly that unique violation.

Closes #499
