### PR TITLE
#518: ask the user to try again when GitHub refuses the code

### DIFF
--- a/front/front_login.rb
+++ b/front/front_login.rb
@@ -28,9 +28,15 @@ end
 get '/github-callback' do
   code = params[:code]
   error(400) if code.nil?
+  begin
+    user = settings.glogin.user(code)
+  rescue StandardError => e
+    settings.log.error(e.message)
+    flash('/', 'The login didn\'t work out, please try again', color: 'darkred')
+  end
   response.set_cookie(
     :glogin, GLogin::Cookie::Open.new(
-      settings.glogin.user(code),
+      user,
       settings.config['github']['encryption_secret'],
       context
     ).to_s

--- a/test/test_github_callback.rb
+++ b/test/test_github_callback.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require 'rack/test'
+require_relative 'test__helper'
+
+require_relative '../0rsk'
+
+class Rsk::GithubCallbackTest < TestCase
+  include Rack::Test::Methods
+
+  def app
+    Sinatra::Application
+  end
+
+  def test_answers_a_refused_code_with_a_message
+    refusing = Object.new
+    refusing.define_singleton_method(:user) do |_code|
+      raise(RuntimeError, 'HTTP error #401 with code abc: bad_verification_code')
+    end
+    refusing.define_singleton_method(:login_uri) { 'https://github.com/login/oauth/authorize' }
+    origin = Sinatra::Application.settings.glogin
+    begin
+      Sinatra::Application.set(:glogin, refusing)
+      get('/github-callback?code=already-used')
+      assert_equal(302, last_response.status, last_response.body)
+      refute_includes(last_response.body, '<pre', last_response.body)
+      assert_includes(last_response.headers['Set-Cookie'].to_s, 'flash_msg', last_response.headers.to_s)
+    ensure
+      Sinatra::Application.set(:glogin, origin)
+    end
+  end
+end


### PR DESCRIPTION
`settings.glogin.user(code)` raises a plain `RuntimeError` on any non-200 from GitHub, and `GLogin::ConnectionError` when GitHub is unreachable. Neither is a `Rsk::Urror`, so both landed in the else branch of the error handler and rendered the 503 page with the backtrace on it. A user who refreshes the callback tab, or comes back to a code GitHub has already spent, is the ordinary way to hit this.

It is rescued now: the reason goes to the log and the user is asked to try logging in again.

The test swaps `settings.glogin` for a double that refuses the code, so it covers the rescue without a stubbing gem and without reaching github.com on every CI run.

Closes #518
