### PR TITLE
#540: count the tasks only for a page that shows them

### DIFF
--- a/front/front_login.rb
+++ b/front/front_login.rb
@@ -22,7 +22,6 @@ before '/*' do
       response.delete_cookie('glogin')
     end
   end
-  @locals[:tasks_count] = tasks.count if @locals[:user]
 end
 
 get '/github-callback' do

--- a/front/front_misc.rb
+++ b/front/front_misc.rb
@@ -16,7 +16,7 @@ end
 get '/favicon.svg' do
   content_type 'image/svg+xml'
   response.headers['Cache-Control'] = 'no-cache'
-  count = tasks_count
+  count = agenda
   display = count > 99 ? '99+' : count.to_s
   color = count.zero? ? '#888' : '#C5283D'
   sz = count > 9 ? 10 : 14
@@ -56,12 +56,12 @@ module Rsk::Misc
     "#{request.ip} #{request.user_agent} #{Rsk::VERSION} #{Time.now.strftime('%Y/%m')}"
   end
 
-  def tasks_count
-    @tasks_count ||= @locals[:user] ? tasks.count : 0
+  def agenda
+    @agenda ||= @locals[:user] ? tasks.count : 0
   end
 
   def merged(hash)
-    out = @locals.merge(tasks_count: tasks_count).merge(hash)
+    out = @locals.merge(tasks_count: agenda).merge(hash)
     out[:local_assigns] = out
     if request.cookies['flash_msg']
       out[:flash_msg] = request.cookies['flash_msg']

--- a/front/front_misc.rb
+++ b/front/front_misc.rb
@@ -16,7 +16,7 @@ end
 get '/favicon.svg' do
   content_type 'image/svg+xml'
   response.headers['Cache-Control'] = 'no-cache'
-  count = @locals[:tasks_count] || 0
+  count = tasks_count
   display = count > 99 ? '99+' : count.to_s
   color = count.zero? ? '#888' : '#C5283D'
   sz = count > 9 ? 10 : 14
@@ -56,8 +56,12 @@ module Rsk::Misc
     "#{request.ip} #{request.user_agent} #{Rsk::VERSION} #{Time.now.strftime('%Y/%m')}"
   end
 
+  def tasks_count
+    @tasks_count ||= @locals[:user] ? tasks.count : 0
+  end
+
   def merged(hash)
-    out = @locals.merge(hash)
+    out = @locals.merge(tasks_count: tasks_count).merge(hash)
     out[:local_assigns] = out
     if request.cookies['flash_msg']
       out[:flash_msg] = request.cookies['flash_msg']

--- a/test/test_tasks_count.rb
+++ b/test/test_tasks_count.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require 'rack/test'
+require 'securerandom'
+require_relative 'test__helper'
+
+require_relative '../0rsk'
+
+class Rsk::TasksCountTest < TestCase
+  include Rack::Test::Methods
+
+  def app
+    Sinatra::Application
+  end
+
+  def test_serves_the_plain_pages_without_counting
+    login = "u#{SecureRandom.hex(8)}"
+    Rsk::Projects.new(test_pgsql, login).add("p#{SecureRandom.hex(8)}")
+    set_cookie("glogin=#{login}")
+    ['/version', '/robots.txt'].each do |uri|
+      get(uri)
+      assert_equal(200, last_response.status, "#{uri}: #{last_response.body}")
+    end
+  end
+
+  def test_shows_the_count_in_the_favicon
+    login = "u#{SecureRandom.hex(8)}"
+    Rsk::Projects.new(test_pgsql, login).add("p#{SecureRandom.hex(8)}")
+    set_cookie("glogin=#{login}")
+    get('/favicon.svg')
+    assert_equal(200, last_response.status, last_response.body)
+    assert_includes(last_response.body, '<svg', last_response.body)
+  end
+end


### PR DESCRIPTION
The `before` filter counted the tasks on every request from a logged-in user, and that count is the twelve-table join behind `/tasks`. `/robots.txt` and `/version` paid for it without ever showing it, and `/favicon.svg` is served with `Cache-Control: no-cache`, so a browser asks for it again on every page view.

The count is computed on demand now and memoised for the request, so a page that shows it pays once and a page that does not pay nothing.

The layout still reads the `tasks_count` local, which `merged` fills in, so the views are unchanged.


Closes #540
