### PR TITLE
#501: skip an update that carries no message

### DIFF
--- a/front/front_telegram.rb
+++ b/front/front_telegram.rb
@@ -98,6 +98,19 @@ module Rsk::Telegram
     end
   end
 
+  def incoming(message)
+    return if message.nil?
+    chat = message.chat.id
+    if telechats.exists?(chat)
+      dispatch(chat, message)
+    else
+      telepost(
+        "[Click here](https://www.0rsk.com/telegram?token=#{telechats.invite(chat)}) to identify yourself.",
+        chat
+      )
+    end
+  end
+
   def dispatch(chat, message)
     login = telechats.login(chat)
     response =
@@ -217,15 +230,7 @@ Object.include(Rsk::Telegram)
 if settings.config['telegram']
   Rsk::Daemon.new.start do
     Telebot::Bot.new(settings.config['telegram']['token']).run do |_, message|
-      chat = message.chat.id
-      if telechats.exists?(chat)
-        dispatch(chat, message)
-      else
-        telepost(
-          "[Click here](https://www.0rsk.com/telegram?token=#{telechats.invite(chat)}) to identify yourself.",
-          chat
-        )
-      end
+      incoming(message)
     end
   rescue Net::ReadTimeout => e
     settings.log.error(e.message)

--- a/test/test_telegram_incoming.rb
+++ b/test/test_telegram_incoming.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'test__helper'
+
+require_relative '../0rsk'
+
+class Rsk::TelegramIncomingTest < TestCase
+  def test_skips_an_update_that_carries_no_message
+    assert_nil(Object.new.extend(Rsk::Telegram).incoming(nil))
+  end
+end


### PR DESCRIPTION
`getUpdates` is called with no `allowed_updates`, so Telegram sends every update type. `Telebot::Update` only carries `update_id` and `message`, so for an `edited_message`, a `my_chat_member` or a `callback_query` the block got `nil` and `message.chat.id` raised.
The block runs before `Bot#run` records the update id, so the exception escaped with the update still unconfirmed. `Rsk::Daemon` caught it, waited a minute and built a fresh `Telebot::Bot`, whose offset starts empty, so Telegram sent the same update again. The bot stayed stuck on it, for every user, until Telegram dropped it about a day later.
A user long-pressing their own message and tapping Edit is enough to trigger it.
The loop body moved into `incoming`, which skips an update with no message, and is a method a test can call.

Closes #501
