### PR TITLE
#502: require the classes the alone daemon uses

### DIFF
--- a/front/front_telegram.rb
+++ b/front/front_telegram.rb
@@ -6,9 +6,11 @@
 require 'telebot'
 require_relative '../objects/daemon'
 require_relative '../objects/markdown'
+require_relative '../objects/projects'
 require_relative '../objects/telechats'
 require_relative '../objects/telepings'
 require_relative '../objects/trimmed'
+require_relative '../objects/triples'
 require_relative '../objects/urror'
 
 get '/telegram' do

--- a/test/test_telegram_requires.rb
+++ b/test/test_telegram_requires.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require 'shellwords'
+require_relative 'test__helper'
+
+class Rsk::TelegramRequiresTest < TestCase
+  def test_loads_the_classes_the_alone_daemon_needs
+    assert_equal(
+      'constant,constant',
+      `#{Shellwords.escape(RbConfig.ruby)} -e #{Shellwords.escape(
+        "require '#{File.expand_path('..', __dir__)}/0rsk'; " \
+        "print [defined?(Rsk::Projects), defined?(Rsk::Triples)].join(',')"
+      )} 2>/dev/null`,
+      'both classes must be loaded before any request is served'
+    )
+  end
+end


### PR DESCRIPTION
`alone` builds `Rsk::Projects` and `Rsk::Triples`, but neither is required anywhere at load time: both are pulled in lazily inside `Rsk::App#projects` and `#triples`, which only run when a web request calls those helpers.
The daemon starts about a second after boot and its first pass runs straight away, so on a fresh process it raises `NameError: uninitialized constant Rsk::Projects` before any request has come in. The rescue sits inside the per-user loop, so it fires once per user, logs, and moves on, and the whole pass quietly does nothing. Then the daemon sleeps for a day.
So after every restart the "risks without a response plan" notification is lost for that day, and Sentry collects one `NameError` per registered user.
The test loads the app in a separate process, the way a fresh boot does, and asks whether both classes are there.

Closes #502
