### PR TITLE
#504: match a command against the whole message

### DIFF
--- a/front/front_telegram.rb
+++ b/front/front_telegram.rb
@@ -49,7 +49,7 @@ module Rsk::Telegram
 
   def reply(msg, login)
     case msg
-    when %r{^/done$}
+    when %r{\A/done(?:@\w+)?\s*\z}i
       left = tasks(login: login).fetch(limit: 100)
       if left.empty?
         ['There are no tasks in your agenda, nothing to complete.']
@@ -72,8 +72,8 @@ module Rsk::Telegram
           resize_keyboard: true
         }
       end
-    when %r{^/done [0-9]+$}
-      id = Integer(msg.split[1])
+    when %r{\A/done(?:@\w+)?\s+(?<id>[0-9]+)\s*\z}i
+      id = Integer(Regexp.last_match[:id])
       tasks(login: login).done(id)
       left = tasks(login: login).fetch
       [
@@ -82,7 +82,7 @@ module Rsk::Telegram
           'Your agenda is empty, good job!' :
           "There are still #{left.count} tasks in your agenda. Say /tasks to see them all."
       ]
-    when %r{^/tasks$}
+    when %r{\A/tasks(?:@\w+)?\s*\z}i
       list = tasks(login: login).fetch(limit: 100)
       if list.empty?
         ['There are no tasks in your agenda, good job!']

--- a/test/test_telegram_reply.rb
+++ b/test/test_telegram_reply.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'test__helper'
+
+require_relative '../0rsk'
+
+class Rsk::TelegramReplyTest < TestCase
+  def test_answers_a_command_that_carries_a_bot_name
+    assert_includes(said('/tasks@zerorsk_bot'), 'agenda', 'a command in a group must be understood')
+  end
+
+  def test_refuses_a_command_buried_in_a_message
+    assert_includes(said("please\n/done 7"), "didn't understand", 'only the whole message is a command')
+  end
+
+  private
+
+  def said(msg)
+    empty = Object.new
+    empty.define_singleton_method(:fetch) { |**| [] }
+    bot = Object.new.extend(Rsk::Telegram)
+    bot.define_singleton_method(:tasks) { |**| empty }
+    bot.reply(msg, 'jeff').flatten.join(' ')
+  end
+end


### PR DESCRIPTION
The three commands were matched with `^` and `$`, which anchor to a line, not to the message. So a message whose second line happened to be `/done 7` matched, and the handler then read the id with `msg.split[1]`, which is `/done` in that case, so `Integer` raised and the user was answered with `invalid value for Integer(): "/done"`.
The same anchors made group chats impossible: Telegram delivers commands there as `/done@yourbot`, which matched nothing, so the bot answered "I didn't understand you". `telechat.id` was widened to a bigint for group chats, so they are meant to work.
The commands are anchored to the whole message now, a trailing `@botname` and surrounding spaces are allowed, and the id comes out of the match rather than out of `split`.
```
"/done"             MENU        "/done 7"           DONE 7
"/done "            MENU        "/done@bot 7"       DONE 7
"/DONE"             MENU        "please\n/done 7"   UNKNOWN
"/done@zerorsk_bot" MENU        "/done 7\nthanks"   UNKNOWN
```

Closes #504
