### PR TITLE
#503: remember the message after it has gone out

### DIFF
--- a/front/front_telegram.rb
+++ b/front/front_telegram.rb
@@ -37,7 +37,6 @@ module Rsk::Telegram
 
   def telepost(msg, chat = telechats.chat(identity), reply_markup: nil)
     return unless settings.config['telegram']
-    telechats.posted(msg, chat)
     telebot.send_message(
       chat_id: chat,
       parse_mode: 'Markdown',
@@ -45,6 +44,7 @@ module Rsk::Telegram
       text: Rsk::Trimmed.new(msg, 4000).to_s,
       reply_markup: reply_markup
     )
+    telechats.posted(msg, chat)
   end
 
   def reply(msg, login)

--- a/test/test_telepost.rb
+++ b/test/test_telepost.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'test__helper'
+
+require_relative '../0rsk'
+
+class Rsk::TelepostTest < TestCase
+  def test_forgets_a_message_that_never_went_out
+    seen = []
+    chats = Object.new
+    chats.define_singleton_method(:posted) { |msg, _chat| seen << msg }
+    bot = Object.new.extend(Rsk::Telegram)
+    bot.define_singleton_method(:telechats) { chats }
+    bot.define_singleton_method(:settings) do
+      Object.new.tap { |s| s.define_singleton_method(:config) { { 'telegram' => { 'token' => 'x' } } } }
+    end
+    bot.define_singleton_method(:telebot) do
+      Object.new.tap do |t|
+        t.define_singleton_method(:send_message) { |**| raise(RuntimeError, 'Telegram is down') }
+      end
+    end
+    assert_raises(RuntimeError) { bot.telepost('hello', 1) }
+    assert_empty(seen, 'a message that failed to go out must not be remembered')
+  end
+end


### PR DESCRIPTION
`telepost` wrote `telechat.recent` before it called `send_message`, so a send that failed, because Telegram refused the message or the user had blocked the bot, still left the message recorded as the last one posted.
`broadcast` and `alone` only send when `telechats.diff?` says the text differs from `recent`. On the next pass the text is identical, so it is suppressed, and the user is counted as reminded without ever having been reminded. In `broadcast` the suppressed pass also refreshes `teleping.updated`, so `required?` goes quiet for another four hours.
The row is written after the send now, so a failure leaves `recent` alone and the next pass tries again.

Closes #503
