### PR TITLE
#525: say that the linking page needs a login

### DIFF
--- a/front/front_telegram.rb
+++ b/front/front_telegram.rb
@@ -12,6 +12,9 @@ require_relative '../objects/trimmed'
 require_relative '../objects/urror'
 
 get '/telegram' do
+  unless @locals[:user]
+    flash('/', 'Log in first, then open the link the bot sent you again', color: 'darkred')
+  end
   haml :telegram, layout: :layout, locals: merged(title: '/telegram', token: params[:token].to_s)
 end
 

--- a/test/test_telegram_page.rb
+++ b/test/test_telegram_page.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require 'rack/test'
+require 'securerandom'
+require_relative 'test__helper'
+
+require_relative '../0rsk'
+
+class Rsk::TelegramPageTest < TestCase
+  include Rack::Test::Methods
+
+  def app
+    Sinatra::Application
+  end
+
+  def test_tells_an_anonymous_visitor_to_log_in
+    clear_cookies
+    get('/telegram?token=whatever')
+    assert_equal(302, last_response.status, last_response.body)
+    assert_includes(last_response.headers['Set-Cookie'].to_s, 'Log', last_response.headers.to_s)
+  end
+
+  def test_shows_the_form_to_a_user
+    set_cookie("glogin=u#{SecureRandom.hex(8)}")
+    get('/telegram?token=whatever')
+    assert_equal(200, last_response.status, last_response.body)
+    assert_includes(last_response.body, 'Link', last_response.body)
+  end
+end


### PR DESCRIPTION
`GET /telegram` rendered the confirmation form to anybody, but `POST /telegram` calls `identity`, which redirects to `/` with nothing said when there is no user. So somebody arriving from the bot, usually on a phone and usually not logged in, saw the page, pressed Link and landed on the home page with no explanation and no way to resume, because the link is back in the Telegram chat.
The page now says what to do before showing the form.

Closes #525
