### PR TITLE
#520: guard a formula that hides behind a space

### DIFF
--- a/0rsk.rb
+++ b/0rsk.rb
@@ -347,7 +347,7 @@ module Rsk::App
 
   def cell(text)
     value = text.to_s
-    value.start_with?('=', '+', '-', '@') ? "'#{value}" : value
+    value.lstrip.start_with?('=', '+', '-', '@') ? "'#{value}" : value
   end
 
   def to_csv(filename, header, rows)

--- a/test/test_csv_cell.rb
+++ b/test/test_csv_cell.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'test__helper'
+
+require_relative '../0rsk'
+
+class Rsk::CsvCellTest < TestCase
+  def test_quotes_a_formula_whatever_it_starts_with
+    ['=1+1', '@SUM(1)', "\t=cmd|'/c calc'!A1", "\r=1+1", ' -1+1'].each do |bad|
+      assert(Object.new.extend(Rsk::App).cell(bad).start_with?("'"), "#{bad.inspect} must be quoted")
+    end
+  end
+
+  def test_leaves_an_ordinary_text_alone
+    ['hello', '3 apples', 'a=b'].each do |good|
+      assert_equal(good, Object.new.extend(Rsk::App).cell(good))
+    end
+  end
+end


### PR DESCRIPTION
The guard covered `= + - @` at the very start of the value. A spreadsheet strips leading whitespace before it decides whether a cell is a formula, so `"\t=cmd|'/c calc'!A1"` was written out untouched, and tab is not a CSV special character either, so `CSV.generate` did not quote it. The same holds for a carriage return and an ordinary space.

The guard looks past the leading whitespace now, and the value itself is written unchanged.

```
"=1+1"    -> "'=1+1"      "\t=1+1"  -> "'\t=1+1"
"@SUM(1)" -> "'@SUM(1)"   " =1+1"   -> "' =1+1"
```


Closes #520
