### PR TITLE
#515: check the schedule before the plan is inserted

### DIFF
--- a/0rsk.rb
+++ b/0rsk.rb
@@ -21,6 +21,7 @@ require 'telebot'
 require 'time'
 require 'yaml'
 require_relative 'objects/limits'
+require_relative 'objects/schedule'
 require_relative 'objects/urror'
 require_relative 'version'
 
@@ -149,8 +150,9 @@ end
 post '/responses/add' do
   id = Integer(params[:id])
   part = Integer(params[:strategy])
+  schedule = Rsk::Schedule.new(params[:schedule]).to_s
   pid = plans.add(part, params[:plan])
-  plans.get(pid, part).reschedule(params[:schedule].strip)
+  plans.get(pid, part).reschedule(schedule)
   flash("/responses?id=#{id}", "Thanks, plan ##{pid}/#{part} added to the triple ##{id}")
 end
 

--- a/objects/plan.rb
+++ b/objects/plan.rb
@@ -5,6 +5,7 @@
 
 require 'date'
 require_relative 'rsk'
+require_relative 'schedule'
 require_relative 'urror'
 
 class Rsk::Plan
@@ -36,17 +37,10 @@ class Rsk::Plan
   end
 
   def reschedule(text, con: nil)
-    unless /^(daily|weekly|biweekly|monthly|quarterly|annually|\d{2}-\d{2}-\d{4})$/.match?(text)
-      raise(Rsk::Urror, "Schedule can either be a word or a date DD-MM-YYYY: #{text.inspect}")
-    end
-    if /^\d{2}-\d{2}-\d{4}$/.match?(text)
-      begin
-        Date.strptime(text, '%d-%m-%Y')
-      rescue Date::Error
-        raise(Rsk::Urror, "There is no such date in the calendar: #{text.inspect}")
-      end
-    end
-    (con || @pgsql).exec('UPDATE plan SET schedule = $3 WHERE id = $1 AND part = $2', [@id, @part, text])
+    (con || @pgsql).exec(
+      'UPDATE plan SET schedule = $3 WHERE id = $1 AND part = $2',
+      [@id, @part, Rsk::Schedule.new(text).to_s]
+    )
   end
 
   private

--- a/objects/schedule.rb
+++ b/objects/schedule.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require 'date'
+require_relative 'rsk'
+require_relative 'urror'
+
+class Rsk::Schedule
+  WORDS = %w[daily weekly biweekly monthly quarterly annually].freeze
+
+  def initialize(text)
+    @text = text
+  end
+
+  def to_s
+    text = @text.to_s.strip
+    unless Rsk::Schedule::WORDS.include?(text) || /^\d{2}-\d{2}-\d{4}$/.match?(text)
+      raise(Rsk::Urror, "Schedule can either be a word or a date DD-MM-YYYY: #{text.inspect}")
+    end
+    if /^\d{2}-\d{2}-\d{4}$/.match?(text)
+      begin
+        Date.strptime(text, '%d-%m-%Y')
+      rescue Date::Error
+        raise(Rsk::Urror, "There is no such date in the calendar: #{text.inspect}")
+      end
+    end
+    text
+  end
+end

--- a/test/test_responses_add.rb
+++ b/test/test_responses_add.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require 'rack/test'
+require 'securerandom'
+require_relative 'test__helper'
+
+require_relative '../0rsk'
+require_relative '../objects/plans'
+require_relative '../objects/triples'
+
+class Rsk::ResponsesAddTest < TestCase
+  include Rack::Test::Methods
+
+  def app
+    Sinatra::Application
+  end
+
+  def test_adds_no_plan_when_the_schedule_is_refused
+    login = "u#{SecureRandom.hex(8)}"
+    project = Rsk::Projects.new(test_pgsql, login).add("p#{SecureRandom.hex(8)}")
+    risk = Rsk::Risks.new(test_pgsql, project).add("risk #{SecureRandom.hex(8)}")
+    set_cookie("glogin=#{login}")
+    set_cookie("0rsk-project=#{project}")
+    post(
+      "/responses/add?id=#{Rsk::Triples.new(test_pgsql, project).add(
+        Rsk::Causes.new(test_pgsql, project).add("cause #{SecureRandom.hex(8)}"),
+        risk,
+        Rsk::Effects.new(test_pgsql, project).add("effect #{SecureRandom.hex(8)}")
+      )}&strategy=#{risk}&plan=my+plan&schedule=nonsense"
+    )
+    assert_equal(302, last_response.status, last_response.body)
+    assert_equal(0, Rsk::Plans.new(test_pgsql, project).count(query: ''), 'no plan may be left behind')
+  end
+
+  def test_answers_a_missing_schedule_with_a_message
+    login = "u#{SecureRandom.hex(8)}"
+    set_cookie("glogin=#{login}")
+    set_cookie("0rsk-project=#{Rsk::Projects.new(test_pgsql, login).add("p#{SecureRandom.hex(8)}")}")
+    post('/responses/add?id=1&strategy=1&plan=x')
+    assert_equal(302, last_response.status, last_response.body)
+    refute_includes(last_response.body, '<pre', last_response.body)
+  end
+end


### PR DESCRIPTION
`plans.add` commits on its own, and `reschedule` was called afterwards. A schedule the object refuses therefore came back as a red error while the plan was already in the database, attached to the part, carrying the column default of `weekly` and generating tasks. Retrying the form added another one. A missing `schedule` was worse: `nil.strip` raised `NoMethodError`, so the answer was the 503 page, and the plan was still committed.

The check that `Plan#reschedule` used to do inline is now `Rsk::Schedule`, so the route can run it before it inserts anything, and `reschedule` keeps using it. No rule is written twice.

The eight existing tests that call `reschedule` pass unchanged.


Closes #515
