### PR TITLE
#526: refuse a tracker without a repository or a token

### DIFF
--- a/objects/trackers.rb
+++ b/objects/trackers.rb
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: MIT
 
 require_relative 'rsk'
+require_relative 'urror'
 
 class Rsk::Trackers
   def initialize(pgsql, project)
@@ -11,11 +12,13 @@ class Rsk::Trackers
     @project = project
   end
 
+  MAX = 256
+
   def add(repo, token)
     Integer(
       @pgsql.exec(
         'INSERT INTO tracker (project, repo, token) VALUES ($1, $2, $3) RETURNING id',
-        [@project, repo, token]
+        [@project, text(repo, 'repository'), text(token, 'token')]
       )[0]['id'], 10
     )
   end
@@ -37,5 +40,15 @@ class Rsk::Trackers
 
   def delete(id)
     @pgsql.exec('DELETE FROM tracker WHERE id = $1 AND project = $2', [id, @project])
+  end
+
+  private
+
+  def text(value, name)
+    stripped = value.to_s.strip
+    raise(Rsk::Urror, "The #{name} can't be empty") if stripped.empty?
+    raise(Rsk::Urror, "The #{name} is longer than #{Rsk::Trackers::MAX}: #{stripped.length}") if
+      stripped.length > Rsk::Trackers::MAX
+    stripped
   end
 end

--- a/test/test_trackers.rb
+++ b/test/test_trackers.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'test__helper'
+
+require_relative '../objects/trackers'
+
+class Rsk::TrackersTest < TestCase
+  def test_refuses_a_field_the_column_cannot_hold
+    trackers = Rsk::Trackers.new(test_pgsql, test_project)
+    bad = [[nil, 'x'], ['', 'x'], ['  ', 'x'], ['a/b', nil], ['a/b', ''], ['r' * 300, 'x']]
+    bad.each do |repo, token|
+      assert_raises(Rsk::Urror, "#{repo.inspect}/#{token.inspect} must be refused") do
+        trackers.add(repo, token)
+      end
+    end
+  end
+
+  def test_adds_a_tracker
+    trackers = Rsk::Trackers.new(test_pgsql, test_project)
+    trackers.add('  foo/bar  ', 'tkn')
+    assert_equal('foo/bar', trackers.fetch[0][:repo], 'the repository must be trimmed')
+  end
+end


### PR DESCRIPTION
`repo` and `token` went straight into the insert. Both columns are `VARCHAR(256) NOT NULL`, so leaving a field out of the form sent `NULL` and raised `PG::NotNullViolation`, which is not a `Rsk::Urror`, so the answer was the 503 page with the SQL statement printed on it. Submitting the form with a field left blank was quieter and no better: an empty string satisfies `NOT NULL`, so a tracker with an empty repository was listed on the project page with no way to correct it, only delete.

Both fields are trimmed and checked now, so all three cases give a message.

Closes #526
