### PR TITLE
#505: let an invite token expire

### DIFF
--- a/front/front_telegram.rb
+++ b/front/front_telegram.rb
@@ -12,7 +12,8 @@ require_relative '../objects/trimmed'
 require_relative '../objects/urror'
 
 get '/telegram' do
-  haml :telegram, layout: :layout, locals: merged(title: '/telegram', token: params[:token].to_s)
+  token = params[:token].to_s
+  haml(:telegram, layout: :layout, locals: merged(title: '/telegram', token:, chat: telechats.invited(token)))
 end
 
 post '/telegram' do

--- a/objects/telechats.rb
+++ b/objects/telechats.rb
@@ -44,6 +44,17 @@ class Rsk::Telechats
     end
   end
 
+  def invited(token)
+    row = @pgsql.exec(
+      [
+        'SELECT chat FROM teleinvite WHERE token = $1',
+        "AND created > NOW() - INTERVAL '#{Rsk::Telechats::HOURS} hours'"
+      ],
+      [token]
+    ).first
+    row.nil? ? nil : Integer(row['chat'])
+  end
+
   def exists?(id)
     !@pgsql.exec('SELECT * FROM telechat WHERE id = $1', [id]).empty?
   end

--- a/objects/telechats.rb
+++ b/objects/telechats.rb
@@ -8,6 +8,8 @@ require_relative 'rsk'
 require_relative 'urror'
 
 class Rsk::Telechats
+  HOURS = 24
+
   def initialize(pgsql)
     @pgsql = pgsql
   end
@@ -18,13 +20,23 @@ class Rsk::Telechats
 
   def invite(chat)
     token = SecureRandom.uuid
-    @pgsql.exec('INSERT INTO teleinvite (token, chat) VALUES ($1, $2)', [token, chat])
+    @pgsql.transaction do |t|
+      t.exec("DELETE FROM teleinvite WHERE created < NOW() - INTERVAL '#{Rsk::Telechats::HOURS} hours'")
+      t.exec('INSERT INTO teleinvite (token, chat) VALUES ($1, $2)', [token, chat])
+    end
     token
   end
 
   def accept(token, login)
     @pgsql.transaction do |t|
-      rows = t.exec('DELETE FROM teleinvite WHERE token = $1 RETURNING chat', [token])
+      rows = t.exec(
+        [
+          'DELETE FROM teleinvite WHERE token = $1',
+          "AND created > NOW() - INTERVAL '#{Rsk::Telechats::HOURS} hours'",
+          'RETURNING chat'
+        ],
+        [token]
+      )
       raise(Rsk::Urror, 'This link is not valid any more, ask the bot for a new one') if rows.empty?
       chat = Integer(rows[0]['chat'])
       t.exec('INSERT INTO telechat (id, login) VALUES ($1, $2)', [chat, login])

--- a/test/test_telechats_invite.rb
+++ b/test/test_telechats_invite.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require 'securerandom'
+require_relative 'test__helper'
+
+require_relative '../objects/telechats'
+
+class Rsk::TelechatsInviteTest < TestCase
+  def test_refuses_a_token_that_is_too_old
+    chats = Rsk::Telechats.new(test_pgsql)
+    token = chats.invite(rand(1_000_000_000))
+    test_pgsql.exec(
+      "UPDATE teleinvite SET created = NOW() - INTERVAL '#{Rsk::Telechats::HOURS + 1} hours' WHERE token = $1",
+      [token]
+    )
+    assert_nil(chats.invited(token), 'a stale token names no chat')
+    assert_raises(Rsk::Urror) { chats.accept(token, "u#{SecureRandom.hex(8)}") }
+  end
+
+  def test_names_the_chat_a_fresh_token_belongs_to
+    chats = Rsk::Telechats.new(test_pgsql)
+    chat = rand(1_000_000_000)
+    assert_equal(chat, chats.invited(chats.invite(chat)))
+  end
+end

--- a/views/telegram.haml
+++ b/views/telegram.haml
@@ -1,8 +1,15 @@
 - # SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
 - # SPDX-License-Identifier: MIT
-%p
-  Confirm that you want to link this account with the Telegram chat
-  the bot sent you the link from.
-%form{action: iri.cut('/telegram'), method: 'POST'}
-  %input{type: 'hidden', name: 'token', value: token}
-  %input{type: 'submit', value: 'Link'}
+- if chat.nil?
+  %p
+    %span.red This link is not valid any more.
+    Ask the bot for a new one.
+- else
+  %p
+    Confirm that you want to link this account with Telegram chat
+    %code= "##{chat}"
+    \, the one the bot sent you this link from.
+- unless chat.nil?
+  %form{action: iri.cut('/telegram'), method: 'POST'}
+    %input{type: 'hidden', name: 'token', value: token}
+    %input{type: 'submit', value: 'Link'}


### PR DESCRIPTION
`invite` is called for every message from a chat the bot does not know, so anyone who writes to it creates a row, and nothing ever removed one. The `created` column was written and never read, so a token stayed valid for good: it travels in a URL, so it sits in browser history and in access logs, and `accept` binds whichever GitHub account is signed in at that moment to the chat named in the row.

A token expires after a day now, and stale rows are cleared out when the next one is handed out, so the table stops growing on its own.

The page also says which chat it is about to link, instead of "the Telegram chat the bot sent you the link from", which the reader had no way to check. A token that has expired says so and shows no button.

Opened as a draft: it conflicts with #564, which changes the same handler. I will rebase and take it out of draft once that one is merged or closed.

Closes #505
