### PR TITLE
#511: keep the highest ranked triple of a task

### DIFF
--- a/objects/tasks.rb
+++ b/objects/tasks.rb
@@ -106,7 +106,7 @@ class Rsk::Tasks
           'OR LOWER(rpart.text) LIKE $2',
           'OR LOWER(epart.text) LIKE $2)'
         ].join(' '),
-        'ORDER BY task.id ASC) x',
+        'ORDER BY task.id ASC, rank DESC) x',
         'ORDER BY rank DESC'
       ],
       [@login, query.is_a?(Integer) ? query : "%#{query.to_s.downcase.strip.gsub(/[%_]/, '\\\\\0')}%"]

--- a/test/test_tasks_rank.rb
+++ b/test/test_tasks_rank.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require 'securerandom'
+require_relative 'test__helper'
+
+require_relative '../objects/plans'
+require_relative '../objects/tasks'
+require_relative '../objects/triples'
+
+class Rsk::TasksRankTest < TestCase
+  def test_shows_the_worst_triple_a_plan_belongs_to
+    login = "u#{SecureRandom.hex(8)}"
+    project = Rsk::Projects.new(test_pgsql, login).add("p#{SecureRandom.hex(8)}")
+    effect = Rsk::Effects.new(test_pgsql, project).add("effect #{SecureRandom.hex(8)}")
+    Rsk::Effects.new(test_pgsql, project).get(effect).weigh(9)
+    triples = Rsk::Triples.new(test_pgsql, project)
+    { 1 => 'low', 9 => 'high' }.each do |probability, name|
+      risk = Rsk::Risks.new(test_pgsql, project).add("risk #{name} #{SecureRandom.hex(8)}")
+      Rsk::Risks.new(test_pgsql, project).get(risk).weigh(probability)
+      triples.add(Rsk::Causes.new(test_pgsql, project).add("cause #{name} #{SecureRandom.hex(8)}"), risk, effect)
+    end
+    plans = Rsk::Plans.new(test_pgsql, project)
+    plans.get(plans.add(effect, "plan #{SecureRandom.hex(8)}"), effect)
+      .reschedule((Time.now - (5 * 24 * 60 * 60)).strftime('%d-%m-%Y'))
+    tasks = Rsk::Tasks.new(test_pgsql, login)
+    tasks.create
+    assert_equal(81, tasks.fetch[0][:rank], 'a task must show the worst triple it belongs to')
+  end
+end


### PR DESCRIPTION
`SELECT DISTINCT ON (task.id) ... ORDER BY task.id ASC` names only the key it is distinct on, so which of the joined triples survives is up to the planner. Every column that comes from the triple, `rank`, `tid`, `prefix`, `ctext`, `rtext` and `etext`, was taken from whichever row won, and the outer `ORDER BY rank DESC` then sorted `/tasks` by that.

So a plan attached to an effect that takes part in two triples of different severity could be shown at rank 9 with the mild cause and risk, while the real one was 81, and sorted near the bottom of the page. `Telepings#pending` orders the Telegram reminders by the same number.

`Plans#query` already does this correctly, with `ORDER BY plan.id, rank DESC`. The inner ordering here now matches, so each task keeps the worst triple it belongs to.

Closes #511
