### PR TITLE
#536: count the tasks once, and stop at the threshold

### DIFF
--- a/objects/tasks.rb
+++ b/objects/tasks.rb
@@ -11,15 +11,18 @@ require_relative 'rsk'
 class Rsk::Tasks
   THRESHOLD = 8
 
+  INSERT = 'INSERT INTO task (plan) VALUES ($1) ON CONFLICT (plan) DO NOTHING RETURNING id'
+
   def initialize(pgsql, login)
     @pgsql = pgsql
     @login = login
   end
 
   def create
+    room = THRESHOLD - count
     Rsk::Pipeline.new(@pgsql, @login).fetch.each do |p|
-      next if count >= THRESHOLD
-      @pgsql.exec('INSERT INTO task (plan) VALUES ($1) ON CONFLICT (plan) DO NOTHING', [p])
+      break if room <= 0
+      room -= @pgsql.exec(INSERT, [p]).size
     end
   end
 

--- a/test/test_tasks_create.rb
+++ b/test/test_tasks_create.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require 'securerandom'
+require_relative 'test__helper'
+
+require_relative '../objects/plans'
+require_relative '../objects/tasks'
+require_relative '../objects/triples'
+
+class Rsk::TasksCreateTest < TestCase
+  def test_stops_at_the_threshold
+    login = "u#{SecureRandom.hex(8)}"
+    project = Rsk::Projects.new(test_pgsql, login).add("p#{SecureRandom.hex(8)}")
+    effect = Rsk::Effects.new(test_pgsql, project).add("effect #{SecureRandom.hex(8)}")
+    Rsk::Triples.new(test_pgsql, project).add(
+      Rsk::Causes.new(test_pgsql, project).add("cause #{SecureRandom.hex(8)}"),
+      Rsk::Risks.new(test_pgsql, project).add("risk #{SecureRandom.hex(8)}"),
+      effect
+    )
+    plans = Rsk::Plans.new(test_pgsql, project)
+    (Rsk::Tasks::THRESHOLD + 4).times do
+      plans.get(plans.add(effect, "plan #{SecureRandom.hex(8)}"), effect)
+        .reschedule((Time.now - (5 * 24 * 60 * 60)).strftime('%d-%m-%Y'))
+    end
+    tasks = Rsk::Tasks.new(test_pgsql, login)
+    tasks.create
+    assert_equal(Rsk::Tasks::THRESHOLD, tasks.count, 'no more than the threshold may be created')
+    tasks.create
+    assert_equal(Rsk::Tasks::THRESHOLD, tasks.count, 'a second run must add nothing')
+  end
+end


### PR DESCRIPTION
`count` is the twelve-table join behind `/tasks`, and it was called once per pipeline entry. The guard was `next` rather than `break`, so the loop kept paying for it long after the threshold was reached, and a pass with nothing to do cost the same as a pass that created everything.

Measured on a project with 30 due plans:

```
before: 39 statements
after:  10 statements
```

The count is read once now, and the loop stops as soon as there is no room left. `RETURNING id` tells it whether the insert actually happened, since `ON CONFLICT DO NOTHING` may add nothing, so the tally stays right without asking the database again.

The eight existing tests pass unchanged.

Closes #536
