### PR TITLE
#534: look the task up inside the transaction that removes it

### DIFF
--- a/objects/tasks.rb
+++ b/objects/tasks.rb
@@ -24,8 +24,8 @@ class Rsk::Tasks
   end
 
   def done(id)
-    row = plan(id)
     @pgsql.transaction do |t|
+      row = plan(id, t)
       t.exec('DELETE FROM task WHERE id = $1', [id])
       Rsk::Plans.new(@pgsql, Integer(row['project']))
         .get(Integer(row['id']), Integer(row['part']), con: t)
@@ -34,8 +34,8 @@ class Rsk::Tasks
   end
 
   def postpone(id, seconds)
-    row = plan(id)
     @pgsql.transaction do |t|
+      row = plan(id, t)
       t.exec('DELETE FROM task WHERE id = $1', [id])
       plan = Rsk::Plans.new(@pgsql, Integer(row['project'])).get(Integer(row['id']), Integer(row['part']), con: t)
       raise(Rsk::Urror, "Can't postpone plan ##{row['id']}") if /^[a-z]+$/.match?(plan.schedule(con: t))
@@ -113,8 +113,10 @@ class Rsk::Tasks
     )
   end
 
-  def plan(id)
-    project = @pgsql.exec(
+  def plan(id, con = @pgsql)
+    raise(Rsk::Urror, "Task ##{id} is not there any more") if
+      con.exec('SELECT id FROM task WHERE id = $1 FOR UPDATE', [id]).empty?
+    project = con.exec(
       [
         'SELECT project.* FROM project',
         'JOIN part ON part.project = project.id',
@@ -126,7 +128,7 @@ class Rsk::Tasks
     )[0]
     raise(Rsk::Urror, "Task ##{id} not found in projects of #{@login}") if project.nil?
     raise(Rsk::Urror, "Task ##{id} doesn't belong to #{@login}") if project['login'] != @login
-    row = @pgsql.exec('SELECT plan.* FROM plan JOIN task ON task.plan = plan.id WHERE task.id = $1', [id])[0]
+    row = con.exec('SELECT plan.* FROM plan JOIN task ON task.plan = plan.id WHERE task.id = $1', [id])[0]
     raise(Rsk::Urror, "Plan for task ##{id} not found") if row.nil?
     row.merge('project' => project['id'])
   end

--- a/test/test_tasks_done.rb
+++ b/test/test_tasks_done.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require 'securerandom'
+require_relative 'test__helper'
+
+require_relative '../objects/plans'
+require_relative '../objects/tasks'
+require_relative '../objects/triples'
+
+class Rsk::TasksDoneTest < TestCase
+  def test_refuses_a_task_that_is_already_gone
+    login = "u#{SecureRandom.hex(8)}"
+    project = Rsk::Projects.new(test_pgsql, login).add("p#{SecureRandom.hex(8)}")
+    effect = Rsk::Effects.new(test_pgsql, project).add("effect #{SecureRandom.hex(8)}")
+    Rsk::Triples.new(test_pgsql, project).add(
+      Rsk::Causes.new(test_pgsql, project).add("cause #{SecureRandom.hex(8)}"),
+      Rsk::Risks.new(test_pgsql, project).add("risk #{SecureRandom.hex(8)}"),
+      effect
+    )
+    plans = Rsk::Plans.new(test_pgsql, project)
+    plans.get(plans.add(effect, "plan #{SecureRandom.hex(8)}"), effect)
+      .reschedule((Time.now - (5 * 24 * 60 * 60)).strftime('%d-%m-%Y'))
+    tasks = Rsk::Tasks.new(test_pgsql, login)
+    tasks.create
+    id = tasks.fetch[0][:id]
+    tasks.done(id)
+    assert_raises(Rsk::Urror) { tasks.done(id) }
+    assert_raises(Rsk::Urror) { tasks.postpone(id, 60) }
+  end
+end


### PR DESCRIPTION
`plan(id)` read the task, the project and the plan on connections of its own, and only then did the transaction start and delete the task. Between the read and the delete another request can remove the same task, and then `complete(con: t)` reaches `Plan#schedule`, whose `[0]['schedule']` is called on an empty result. That is not a `Rsk::Urror`, so the answer is the 503 page.

A double click is enough, and the two callers need not be browsers: the Telegram `/done N` handler runs on the bot thread while the same task can be completed from the page.

The lookup happens inside the transaction now, on the same connection, and it takes `FOR UPDATE` on the task row first, so a second caller waits for the first to commit and then finds the row gone and is told so.

On what I could verify: the window itself is plain to see in the code, and the new test covers the deterministic half of it, a second `done` on a task that is already finished. I could not make the exact `NoMethodError` appear on my machine, where the losing thread already failed earlier in the lookup, on master as well as with this change. So the crash is reasoned from the code and the report, not reproduced here.

Closes #534
