### PR TITLE
#512: sort the items with no rank last

### DIFF
--- a/objects/causes.rb
+++ b/objects/causes.rb
@@ -82,7 +82,7 @@ class Rsk::Causes
         'LEFT JOIN effect ON triple.effect = effect.id',
         'WHERE project = $1 AND (LOWER(text) LIKE $2 OR emoji LIKE $2)',
         'GROUP BY cause.id, part.id',
-        'ORDER BY rank DESC'
+        'ORDER BY rank DESC NULLS LAST'
       ],
       [@project, "%#{query.to_s.downcase.strip.gsub(/[%_]/, '\\\\\0')}%"]
     )

--- a/objects/effects.rb
+++ b/objects/effects.rb
@@ -74,7 +74,7 @@ class Rsk::Effects
         'WHERE project = $1',
         'AND LOWER(text) LIKE $2',
         'GROUP BY effect.id, part.id',
-        'ORDER BY rank DESC'
+        'ORDER BY rank DESC NULLS LAST'
       ],
       [@project, "%#{query.to_s.downcase.strip.gsub(/[%_]/, '\\\\\0')}%"]
     )

--- a/objects/plans.rb
+++ b/objects/plans.rb
@@ -82,7 +82,7 @@ class Rsk::Plans
         (query.is_a?(Integer) ? '  triple.id = $2' : '  LOWER(part.text) LIKE $2'),
         '  ORDER BY plan.id, rank DESC',
         ') sub',
-        'ORDER BY rank DESC'
+        'ORDER BY rank DESC NULLS LAST'
       ],
       [@project, query.is_a?(Integer) ? query : "%#{query.to_s.downcase.strip.gsub(/[%_]/, '\\\\\0')}%"]
     )

--- a/objects/risks.rb
+++ b/objects/risks.rb
@@ -69,7 +69,7 @@ class Rsk::Risks
         'LEFT JOIN effect ON triple.effect = effect.id',
         'WHERE project = $1 AND LOWER(text) LIKE $2',
         'GROUP BY risk.id, part.id',
-        'ORDER BY rank DESC'
+        'ORDER BY rank DESC NULLS LAST'
       ],
       [@project, "%#{query.to_s.downcase.strip.gsub(/[%_]/, '\\\\\0')}%"]
     )

--- a/test/test_causes_order.rb
+++ b/test/test_causes_order.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require 'securerandom'
+require_relative 'test__helper'
+
+require_relative '../objects/causes'
+require_relative '../objects/triples'
+
+class Rsk::CausesOrderTest < TestCase
+  def test_puts_a_cause_with_no_rank_last
+    project = test_project
+    linked = "linked #{SecureRandom.hex(8)}"
+    risk = test_risk(project: project)
+    Rsk::Risks.new(test_pgsql, project).get(risk).weigh(9)
+    effect = test_effect(project: project)
+    Rsk::Effects.new(test_pgsql, project).get(effect).weigh(9)
+    Rsk::Triples.new(test_pgsql, project).add(Rsk::Causes.new(test_pgsql, project).add(linked), risk, effect)
+    Rsk::Causes.new(test_pgsql, project).add("lonely #{SecureRandom.hex(8)}")
+    assert_equal(linked, Rsk::Causes.new(test_pgsql, project).fetch[0][:text], 'the ranked one comes first')
+  end
+end


### PR DESCRIPTION
`rank` is computed over `LEFT JOIN`s, so an item that belongs to no triple yields `NULL`. Postgres sorts `DESC` with `NULLS FIRST`, so every unranked cause, risk, effect and plan came before the most severe one. The Ruby side reads it as `Integer(r['rank'] || 0)`, so the page showed a block of zeros at the top of a list that says it is ordered by rank.

With the default limit of 25 a project with many unlinked parts pushed its real risks off the first page.

The four queries end with `NULLS LAST` now.

The existing tests for the four classes pass unchanged; they each build a single item, so ordering was never exercised.

Closes #512
