### PR TITLE
#531: escape the backslash the way LIKE reads it

### DIFF
--- a/objects/causes.rb
+++ b/objects/causes.rb
@@ -84,7 +84,7 @@ class Rsk::Causes
         'GROUP BY cause.id, part.id',
         'ORDER BY rank DESC'
       ],
-      [@project, "%#{query.to_s.downcase.strip.gsub(/[%_]/, '\\\\\0')}%"]
+      [@project, "%#{query.to_s.downcase.strip.gsub(/[\\%_]/, '\\\\\0')}%"]
     )
   end
 end

--- a/objects/effects.rb
+++ b/objects/effects.rb
@@ -76,7 +76,7 @@ class Rsk::Effects
         'GROUP BY effect.id, part.id',
         'ORDER BY rank DESC'
       ],
-      [@project, "%#{query.to_s.downcase.strip.gsub(/[%_]/, '\\\\\0')}%"]
+      [@project, "%#{query.to_s.downcase.strip.gsub(/[\\%_]/, '\\\\\0')}%"]
     )
   end
 end

--- a/objects/plans.rb
+++ b/objects/plans.rb
@@ -84,7 +84,7 @@ class Rsk::Plans
         ') sub',
         'ORDER BY rank DESC'
       ],
-      [@project, query.is_a?(Integer) ? query : "%#{query.to_s.downcase.strip.gsub(/[%_]/, '\\\\\0')}%"]
+      [@project, query.is_a?(Integer) ? query : "%#{query.to_s.downcase.strip.gsub(/[\\%_]/, '\\\\\0')}%"]
     )
   end
 end

--- a/objects/risks.rb
+++ b/objects/risks.rb
@@ -71,7 +71,7 @@ class Rsk::Risks
         'GROUP BY risk.id, part.id',
         'ORDER BY rank DESC'
       ],
-      [@project, "%#{query.to_s.downcase.strip.gsub(/[%_]/, '\\\\\0')}%"]
+      [@project, "%#{query.to_s.downcase.strip.gsub(/[\\%_]/, '\\\\\0')}%"]
     )
   end
 end

--- a/objects/tasks.rb
+++ b/objects/tasks.rb
@@ -109,7 +109,7 @@ class Rsk::Tasks
         'ORDER BY task.id ASC) x',
         'ORDER BY rank DESC'
       ],
-      [@login, query.is_a?(Integer) ? query : "%#{query.to_s.downcase.strip.gsub(/[%_]/, '\\\\\0')}%"]
+      [@login, query.is_a?(Integer) ? query : "%#{query.to_s.downcase.strip.gsub(/[\\%_]/, '\\\\\0')}%"]
     )
   end
 

--- a/objects/triples.rb
+++ b/objects/triples.rb
@@ -137,7 +137,7 @@ class Rsk::Triples
         where.empty? ? '' : "AND (#{where.join(') AND (')})",
         'ORDER BY rank DESC, t.created DESC'
       ],
-      [@project, id.positive? ? id : "%#{words.join(' ').gsub(/[%_]/, '\\\\\0')}%"]
+      [@project, id.positive? ? id : "%#{words.join(' ').gsub(/[\\%_]/, '\\\\\0')}%"]
     )
   end
 end

--- a/test/test_causes_search.rb
+++ b/test/test_causes_search.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require 'securerandom'
+require_relative 'test__helper'
+
+require_relative '../objects/causes'
+
+class Rsk::CausesSearchTest < TestCase
+  def test_finds_a_text_that_carries_a_backslash
+    causes = Rsk::Causes.new(test_pgsql, test_project)
+    salt = SecureRandom.hex(8)
+    causes.add("c:\\windows\\#{salt}")
+    causes.add("one hundred % #{salt}")
+    causes.add("snake_case #{salt}")
+    assert_equal(1, causes.count(query: 'c:\\windows'), 'a backslash must be looked for as it is')
+    assert_equal(1, causes.count(query: 'hundred %'), 'a percent sign must still be escaped')
+    assert_equal(1, causes.count(query: 'snake_case'), 'an underscore must still be escaped')
+  end
+end


### PR DESCRIPTION
The search escapes `%` and `_` before it builds the `LIKE` pattern, but not the escape character itself. `LIKE` has no `ESCAPE` clause here, so it uses the default backslash, and a backslash the user typed swallowed the character after it.

```
"c:\windows"  before: c:\windows    after: c:\\windows
"100%"        before: 100\%         after: 100\%
"snake_case"  before: snake\_case   after: snake\_case
```

So a Windows path, an escape sequence or a regular expression, all of them plausible risk text, could not be found, and the page said "Nothing found, sorry." rather than reporting anything.

All six queries escape the backslash now.

Closes #531
