### PR TITLE
#535: refuse a duplicate without raising through the pool

### DIFF
--- a/objects/causes.rb
+++ b/objects/causes.rb
@@ -15,18 +15,20 @@ class Rsk::Causes
   end
 
   def add(text)
-    @pgsql.transaction do |t|
-      id = Integer(
-        t.exec(
-          'INSERT INTO part (project, text, type) VALUES ($1, $2, $3) RETURNING id',
-          [@project, text, 'Cause']
-        )[0]['id']
-      )
-      t.exec('INSERT INTO cause (id) VALUES ($1)', [id])
-      id
-    end
-  rescue PG::UniqueViolation
-    raise(Rsk::Urror, "Cause \"#{text}\" already exists in this project")
+    id =
+      @pgsql.transaction do |t|
+        next if t.exec('SELECT id FROM part WHERE project = $1 AND text = $2', [@project, text]).any?
+        made = Integer(
+          t.exec(
+            'INSERT INTO part (project, text, type) VALUES ($1, $2, $3) RETURNING id',
+            [@project, text, 'Cause']
+          )[0]['id']
+        )
+        t.exec('INSERT INTO cause (id) VALUES ($1)', [made])
+        made
+      end
+    raise(Rsk::Urror, "Cause \"#{text}\" already exists in this project") if id.nil?
+    id
   end
 
   def emojis

--- a/objects/causes.rb
+++ b/objects/causes.rb
@@ -27,8 +27,10 @@ class Rsk::Causes
         t.exec('INSERT INTO cause (id) VALUES ($1)', [made])
         made
       end
-    raise(Rsk::Urror, "Cause \"#{text}\" already exists in this project") if id.nil?
+    taken(text) if id.nil?
     id
+  rescue PG::UniqueViolation
+    taken(text)
   end
 
   def emojis
@@ -69,6 +71,10 @@ class Rsk::Causes
   end
 
   private
+
+  def taken(text)
+    raise(Rsk::Urror, "Cause \"#{text}\" already exists in this project")
+  end
 
   def query(query)
     Rsk::Query.new(

--- a/objects/effects.rb
+++ b/objects/effects.rb
@@ -27,8 +27,10 @@ class Rsk::Effects
         t.exec('INSERT INTO effect (id) VALUES ($1)', [made])
         made
       end
-    raise(Rsk::Urror, "Effect \"#{text}\" already exists in this project") if id.nil?
+    taken(text) if id.nil?
     id
+  rescue PG::UniqueViolation
+    taken(text)
   end
 
   def get(id)
@@ -60,6 +62,10 @@ class Rsk::Effects
   end
 
   private
+
+  def taken(text)
+    raise(Rsk::Urror, "Effect \"#{text}\" already exists in this project")
+  end
 
   def query(query)
     Rsk::Query.new(

--- a/objects/effects.rb
+++ b/objects/effects.rb
@@ -15,18 +15,20 @@ class Rsk::Effects
   end
 
   def add(text)
-    @pgsql.transaction do |t|
-      id = Integer(
-        t.exec(
-          'INSERT INTO part (project, text, type) VALUES ($1, $2, $3) RETURNING id',
-          [@project, text, 'Effect']
-        )[0]['id']
-      )
-      t.exec('INSERT INTO effect (id) VALUES ($1)', [id])
-      id
-    end
-  rescue PG::UniqueViolation
-    raise(Rsk::Urror, "Effect \"#{text}\" already exists in this project")
+    id =
+      @pgsql.transaction do |t|
+        next if t.exec('SELECT id FROM part WHERE project = $1 AND text = $2', [@project, text]).any?
+        made = Integer(
+          t.exec(
+            'INSERT INTO part (project, text, type) VALUES ($1, $2, $3) RETURNING id',
+            [@project, text, 'Effect']
+          )[0]['id']
+        )
+        t.exec('INSERT INTO effect (id) VALUES ($1)', [made])
+        made
+      end
+    raise(Rsk::Urror, "Effect \"#{text}\" already exists in this project") if id.nil?
+    id
   end
 
   def get(id)

--- a/objects/risks.rb
+++ b/objects/risks.rb
@@ -15,18 +15,20 @@ class Rsk::Risks
   end
 
   def add(text)
-    @pgsql.transaction do |t|
-      id = Integer(
-        t.exec(
-          'INSERT INTO part (project, text, type) VALUES ($1, $2, $3) RETURNING id',
-          [@project, text, 'Risk']
-        )[0]['id']
-      )
-      t.exec('INSERT INTO risk (id) VALUES ($1)', [id])
-      id
-    end
-  rescue PG::UniqueViolation
-    raise(Rsk::Urror, "Risk \"#{text}\" already exists in this project")
+    id =
+      @pgsql.transaction do |t|
+        next if t.exec('SELECT id FROM part WHERE project = $1 AND text = $2', [@project, text]).any?
+        made = Integer(
+          t.exec(
+            'INSERT INTO part (project, text, type) VALUES ($1, $2, $3) RETURNING id',
+            [@project, text, 'Risk']
+          )[0]['id']
+        )
+        t.exec('INSERT INTO risk (id) VALUES ($1)', [made])
+        made
+      end
+    raise(Rsk::Urror, "Risk \"#{text}\" already exists in this project") if id.nil?
+    id
   end
 
   def get(id)

--- a/objects/risks.rb
+++ b/objects/risks.rb
@@ -27,8 +27,10 @@ class Rsk::Risks
         t.exec('INSERT INTO risk (id) VALUES ($1)', [made])
         made
       end
-    raise(Rsk::Urror, "Risk \"#{text}\" already exists in this project") if id.nil?
+    taken(text) if id.nil?
     id
+  rescue PG::UniqueViolation
+    taken(text)
   end
 
   def get(id)
@@ -56,6 +58,10 @@ class Rsk::Risks
   end
 
   private
+
+  def taken(text)
+    raise(Rsk::Urror, "Risk \"#{text}\" already exists in this project")
+  end
 
   def query(query)
     Rsk::Query.new(

--- a/test/test_causes_connection.rb
+++ b/test/test_causes_connection.rb
@@ -27,4 +27,19 @@ class Rsk::CausesConnectionTest < TestCase
     end
     assert_equal(1, backends.uniq.size, "a refused duplicate must not throw the connection away: #{backends}")
   end
+
+  def test_tells_the_losers_of_a_concurrent_add
+    causes = Rsk::Causes.new(test_pgsql, test_project)
+    text = "cause #{SecureRandom.hex(8)}"
+    seen = Array.new(4) do
+      Thread.new do
+        causes.add(text)
+        'added'
+      rescue Rsk::Urror
+        'refused'
+      end
+    end.map(&:value)
+    assert_equal(1, seen.count('added'), "exactly one may win: #{seen}")
+    assert_equal(3, seen.count('refused'), "the losers must be told, not crash: #{seen}")
+  end
 end

--- a/test/test_causes_connection.rb
+++ b/test/test_causes_connection.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require 'loog'
+require 'pgtk/pool'
+require 'securerandom'
+require_relative 'test__helper'
+
+require_relative '../objects/causes'
+require_relative '../objects/projects'
+
+class Rsk::CausesConnectionTest < TestCase
+  def test_keeps_the_connection_after_a_duplicate
+    pool = Pgtk::Pool.new(
+      Pgtk::Wire::Yaml.new(File.join(__dir__, '../target/pgsql-config.yml')), log: Loog::NULL, max: 1
+    )
+    pool.start!
+    causes = Rsk::Causes.new(pool, Rsk::Projects.new(pool, "u#{SecureRandom.hex(8)}").add("p#{SecureRandom.hex(8)}"))
+    text = "cause #{SecureRandom.hex(8)}"
+    causes.add(text)
+    backends = []
+    5.times do
+      assert_raises(Rsk::Urror) { causes.add(text) }
+      backends << pool.exec('SELECT pg_backend_pid() AS p')[0]['p']
+    end
+    assert_equal(1, backends.uniq.size, "a refused duplicate must not throw the connection away: #{backends}")
+  end
+end


### PR DESCRIPTION
`Pgtk::Pool#connect` treats any `StandardError` coming out of the block as a sign the connection is broken, and closes and reopens it. `Causes#add`, `Risks#add` and `Effects#add` let `PG::UniqueViolation` travel out of `@pgsql.transaction` and caught it on the method, so by the time the friendly `Rsk::Urror` was raised the connection had already been thrown away.

Measured against a pool of one connection, ten duplicate adds:

```
before: 10 distinct backends
after:   1
```

So retyping a title that already exists, an ordinary mistake, cost a full reconnect to the database each time.

The duplicate is looked for inside the transaction now, and the block returns nothing instead of raising, so the `Rsk::Urror` is raised after the connection has been handed back.

The check and the insert are not atomic against a concurrent caller, so the `rescue PG::UniqueViolation` stays as the fallback for that. Four callers adding the same text at once, twenty rounds:

```
without the rescue: {"OK"=>20, "PG::UniqueViolation"=>49, "Urror"=>11}
with it:            {"OK"=>20, "Urror"=>60}
```

`Plans#add` has the same shape and is being given the same rescue in #543; it can follow this pattern once that one lands.

Closes #535
