### PR TITLE
#521: keep the paging block outside the table

### DIFF
--- a/test/test_paging_place.rb
+++ b/test/test_paging_place.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require 'nokogiri'
+require 'rack/test'
+require 'securerandom'
+require_relative 'test__helper'
+
+require_relative '../0rsk'
+
+class Rsk::PagingPlaceTest < TestCase
+  include Rack::Test::Methods
+
+  def app
+    Sinatra::Application
+  end
+
+  def test_puts_the_paging_after_the_table
+    login = "u#{SecureRandom.hex(8)}"
+    project = Rsk::Projects.new(test_pgsql, login).add("p#{SecureRandom.hex(8)}")
+    causes = Rsk::Causes.new(test_pgsql, project)
+    4.times { causes.add("cause #{SecureRandom.hex(8)}") }
+    set_cookie("glogin=#{login}")
+    set_cookie("0rsk-project=#{project}")
+    get('/causes?limit=2&offset=2')
+    assert_equal(200, last_response.status, last_response.body)
+    html = Nokogiri::HTML.parse(last_response.body)
+    refute_empty(html.xpath('//table'), last_response.body)
+    paging = html.xpath("//p[contains(@class,'small')][.//a[normalize-space(text())='Previous']]").first
+    refute_nil(paging, "the paging must be there: #{last_response.body}")
+    refute_empty(
+      paging.xpath('preceding::table'),
+      "the paging must come after the table, not before it: #{last_response.body}"
+    )
+  end
+end

--- a/views/causes.haml
+++ b/views/causes.haml
@@ -53,4 +53,4 @@
             = rank(r)
           %td.right
             = r[:risks]
-    = Tilt::HamlTemplate.new('views/_paging.haml', 1, format: :xhtml).render(self, locals.merge(count: causes.count))
+  = Tilt::HamlTemplate.new('views/_paging.haml', 1, format: :xhtml).render(self, locals.merge(count: causes.count))

--- a/views/effects.haml
+++ b/views/effects.haml
@@ -49,4 +49,4 @@
             = rank(r)
           %td.right
             = r[:risks]
-    = Tilt::HamlTemplate.new('views/_paging.haml', 1, format: :xhtml).render(self, locals.merge(count: effects.count))
+  = Tilt::HamlTemplate.new('views/_paging.haml', 1, format: :xhtml).render(self, locals.merge(count: effects.count))

--- a/views/plans.haml
+++ b/views/plans.haml
@@ -54,4 +54,4 @@
           %td.right
             = thumb(r)
             = rank(r)
-    = Tilt::HamlTemplate.new('views/_paging.haml', 1, format: :xhtml).render(self, locals.merge(count: plans.count))
+  = Tilt::HamlTemplate.new('views/_paging.haml', 1, format: :xhtml).render(self, locals.merge(count: plans.count))


### PR DESCRIPTION
The line that renders the paging block sat at the same indentation as `%thead` and `%tbody`, so it was a child of `%table`. `_paging.haml` emits a `<p>`, and an HTML5 parser foster-parents non-table content out of a table, moving it to just before the table. So `/causes`, `/effects` and `/plans` showed Previous, the page numbers and Next above the table, while `/risks`, where the same line is correctly indented, showed them below.

The three now match `views/risks.haml`.

Closes #521
