### PR TITLE
#510: keep the pool helper out of the list of tests

### DIFF
--- a/test/test__helper.rb
+++ b/test/test__helper.rb
@@ -46,6 +46,8 @@ require_relative '../objects/risks'
 require_relative '../objects/triples'
 
 class TestCase < Minitest::Test
+  private
+
   def test_pgsql
     @@mtx ||= Mutex.new
     @@mtx.synchronize do
@@ -56,10 +58,7 @@ class TestCase < Minitest::Test
       @@test_pgsql.start!
     end
     @@test_pgsql
-    # rubocop:enable Style/ClassVars
   end
-
-  private
 
   def test_project(login: "u#{SecureRandom.hex(8)}", title: "t#{SecureRandom.hex(8)}")
     Rsk::Projects.new(test_pgsql, login).add(title)

--- a/test/test_helper_itself.rb
+++ b/test/test_helper_itself.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'test__helper'
+
+class Rsk::HelperTest < TestCase
+  def test_counts_only_the_real_tests
+    assert_equal(
+      ['test_counts_only_the_real_tests'],
+      Rsk::HelperTest.runnable_methods.sort,
+      'the pool helper must not be run as a test'
+    )
+  end
+end


### PR DESCRIPTION
`Minitest::Test.runnable_methods` collects every public method whose name starts with `test_`. `test_pgsql` was defined above the `private` keyword, so all 23 subclasses inherited it as a runnable test, and `TestCase` itself ran it too. Each of those opened the pool and asserted nothing, so the reported run count was about 23 higher than the number of real tests.

```
test_causes.rb  before: 4 tests, 8 assertions   after: 2 tests, 8 assertions
test_plans.rb   before: 14 tests, 23 assertions after: 12 tests, 23 assertions
```

The assertions are unchanged; only the phantom runs are gone.

Every one of the 20 test files calls `test_pgsql` without a receiver, so moving it under `private` needed no change anywhere else. The stray `# rubocop:enable Style/ClassVars`, which had no matching disable, is gone with it.

Opened as a draft: it conflicts with #349, which also changes `test/test__helper.rb`. I will rebase and take it out of draft once that one is merged or closed.

Closes #510
