### PR TITLE
#496: look up the address the server sees

### DIFF
--- a/test/test_footer.rb
+++ b/test/test_footer.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require 'nokogiri'
+require 'rack/test'
+require_relative 'test__helper'
+
+require_relative '../0rsk'
+
+class Rsk::FooterTest < TestCase
+  include Rack::Test::Methods
+
+  def app
+    Sinatra::Application
+  end
+
+  def test_looks_up_the_address_the_server_sees
+    get('/')
+    assert_equal(200, last_response.status, last_response.body)
+    links = Nokogiri::HTML.parse(last_response.body).xpath("//a[contains(@href,'iplocation.com')]")
+    refute_empty(links, last_response.body)
+    assert_includes(links.first['href'], 'ip=127.0.0.1', last_response.body)
+  end
+end

--- a/views/layout.haml
+++ b/views/layout.haml
@@ -111,7 +111,7 @@
             %li{title: 'PostgreSQL version'}
               = "pg:#{settings.pgsql.version}"
             %li{title: 'Your IP address visible to the server'}
-              %a{href: 'https://iplocation.com/?ip=', title: 'Your IP address' + request_ip}
+              %a{href: "https://iplocation.com/?ip=#{request_ip}", title: "Look up #{request_ip}"}
                 = request_ip
             %li{title: 'This request processing time'}
               = "#{((Time.now - http_start) * 1000).round}ms"


### PR DESCRIPTION
The `ip=` parameter was left empty and the address was glued onto the end of the title instead, with no separator, so the tooltip read `Your IP address203.0.113.7`. Clicking the link opened iplocation.com with nothing to look up, so it reported whatever address that site saw rather than the one the server reported, which is the whole point of the link. It is in the footer of every page.

Closes #496
