### PR TITLE
#493: put the schedule word in, not the label around it

### DIFF
--- a/public/js/responses.js
+++ b/public/js/responses.js
@@ -13,9 +13,8 @@ function on_schedule(label, f) {
 
 function on_mnemo(id) {
   "use strict";
-  var $span = $("#" + id);
-  $span.on("click", function() {
-    $("#schedule").val($span.text());
+  $("#" + id).on("click", function() {
+    $("#schedule").val(id);
     return false;
   });
 }


### PR DESCRIPTION
`on_mnemo` filled the field from the link's own text, and the links are written with Haml's `<` whitespace removal, so the punctuation that separates them is part of that text:

```html
<a href="#" id="daily" title="Daily schedule">daily,</a>
...
<a href="#" id="annually" title="Annual schedule">annually):</a>
```

Clicking "daily" therefore put `daily,` into the Schedule field, and `Rsk::Schedule` refuses it, because the pattern is anchored. All six shortcuts were broken the same way.

The id of each link is already the word itself, so the handler uses that instead of the label around it. It cannot break again when somebody edits the punctuation.

There is no browser test suite in this repository (#202), so this is not covered by a test.

Closes #493
