### PR TITLE
#497: turn a bad query parameter into a message

### DIFF
--- a/0rsk.rb
+++ b/0rsk.rb
@@ -71,9 +71,9 @@ get '/' do
 end
 
 get '/ranked' do
-  offset = [Integer(params[:offset] || '0'), 0].max
-  limit = Integer(params[:limit] || '10')
-  query = params[:q] || ''
+  offset = [number(params[:offset] || 0, 'offset'), 0].max
+  limit = number(params[:limit] || 10, 'limit')
+  query = params[:q].to_s
   haml :ranked, layout: :layout, locals: merged(
     title: '/ranked',
     query: query,
@@ -129,14 +129,14 @@ end
 
 post '/project/{id}/tracker/delete' do
   pid = params[:id]
-  tid = Integer(params[:tid], 10)
+  tid = number(params[:tid], 'tid')
   raise Rsk::Urror, "Project ##{pid} not found" unless projects.exists?(pid)
   trackers(pid: pid).delete(tid)
   flash("/project/#{pid}", 'Tracker removed')
 end
 
 get '/responses' do
-  id = Integer(params[:id])
+  id = number(params[:id], 'id')
   triple = triples.fetch(id: id, limit: 1)[0]
   raise(Rsk::Urror, "Triple ##{id} not found") if triple.nil?
   haml :responses, layout: :layout, locals: merged(
@@ -147,25 +147,25 @@ get '/responses' do
 end
 
 post '/responses/add' do
-  id = Integer(params[:id])
-  part = Integer(params[:strategy])
+  id = number(params[:id], 'id')
+  part = number(params[:strategy], 'strategy')
   pid = plans.add(part, params[:plan])
   plans.get(pid, part).reschedule(params[:schedule].strip)
   flash("/responses?id=#{id}", "Thanks, plan ##{pid}/#{part} added to the triple ##{id}")
 end
 
 post '/responses/detach' do
-  tid = Integer(params[:tid])
-  id = Integer(params[:id])
-  part = Integer(params[:part])
+  tid = number(params[:tid], 'tid')
+  id = number(params[:id], 'id')
+  part = number(params[:part], 'part')
   plans.get(id, part).detach
   flash("/responses?id=#{tid}", "Thanks, plan ##{id} detached from the triple ##{tid}")
 end
 
 get '/causes' do
-  offset = [Integer(params[:offset] || '0'), 0].max
-  limit = Integer(params[:limit] || '25')
-  query = params[:q] || ''
+  offset = [number(params[:offset] || 0, 'offset'), 0].max
+  limit = number(params[:limit] || 25, 'limit')
+  query = params[:q].to_s
   haml :causes, layout: :layout, locals: merged(
     title: '/causes',
     query: query,
@@ -178,9 +178,9 @@ get '/causes' do
 end
 
 get '/risks' do
-  offset = [Integer(params[:offset] || '0'), 0].max
-  limit = Integer(params[:limit] || '25')
-  query = params[:q] || ''
+  offset = [number(params[:offset] || 0, 'offset'), 0].max
+  limit = number(params[:limit] || 25, 'limit')
+  query = params[:q].to_s
   haml :risks, layout: :layout, locals: merged(
     title: '/risks',
     query: query,
@@ -192,9 +192,9 @@ get '/risks' do
 end
 
 get '/effects' do
-  offset = [Integer(params[:offset] || '0'), 0].max
-  limit = Integer(params[:limit] || '25')
-  query = params[:q] || ''
+  offset = [number(params[:offset] || 0, 'offset'), 0].max
+  limit = number(params[:limit] || 25, 'limit')
+  query = params[:q].to_s
   haml :effects, layout: :layout, locals: merged(
     title: '/effects',
     query: query,
@@ -206,9 +206,9 @@ get '/effects' do
 end
 
 get '/plans' do
-  offset = [Integer(params[:offset] || '0'), 0].max
-  limit = Integer(params[:limit] || '25')
-  query = params[:q] || ''
+  offset = [number(params[:offset] || 0, 'offset'), 0].max
+  limit = number(params[:limit] || 25, 'limit')
+  query = params[:q].to_s
   haml :plans, layout: :layout, locals: merged(
     title: '/plans',
     query: query,

--- a/front/front_tasks.rb
+++ b/front/front_tasks.rb
@@ -16,9 +16,9 @@ Rsk::Daemon.new(10).start do
 end
 
 get '/tasks' do
-  offset = [Integer(params[:offset] || '0'), 0].max
-  limit = Integer(params[:limit] || '10')
-  query = params[:q] || ''
+  offset = [number(params[:offset] || 0, 'offset'), 0].max
+  limit = number(params[:limit] || 10, 'limit')
+  query = params[:q].to_s
   haml :tasks, layout: :layout, locals: merged(
     title: '/tasks',
     offset: offset,

--- a/front/front_triple.rb
+++ b/front/front_triple.rb
@@ -77,7 +77,7 @@ end
 
 get '/triple' do
   vars = { title: '/triple', project: pid, emojis: causes.emojis }
-  id = Integer(params[:id] || 0)
+  id = number(params[:id] || 0, 'id')
   if id.positive?
     triple = triples.fetch(id: id, limit: 1)[0]
     raise(Rsk::Urror, "Triple ##{id} not found") if triple.nil?

--- a/test/test_bad_params.rb
+++ b/test/test_bad_params.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require 'rack/test'
+require 'securerandom'
+require_relative 'test__helper'
+
+require_relative '../0rsk'
+
+class Rsk::BadParamsTest < TestCase
+  include Rack::Test::Methods
+
+  def app
+    Sinatra::Application
+  end
+
+  def test_shows_no_backtrace_for_a_bad_parameter
+    login = "u#{SecureRandom.hex(8)}"
+    set_cookie("glogin=#{login}")
+    set_cookie("0rsk-project=#{Rsk::Projects.new(test_pgsql, login).add("p#{SecureRandom.hex(8)}")}")
+    [
+      '/ranked?limit=abc', '/ranked?offset[]=1', '/ranked?q[]=a', '/causes?limit=x',
+      '/risks?offset=y', '/effects?limit=z', '/plans?limit=q', '/tasks?limit=w',
+      '/triple?id=', '/responses'
+    ].each do |uri|
+      get(uri)
+      refute_includes(last_response.body, '<pre', "#{uri} shows a backtrace: #{last_response.body[0, 200]}")
+      refute_equal(503, last_response.status, "#{uri} answers 503")
+    end
+  end
+end


### PR DESCRIPTION
Every list route began with a bare `Integer(...)` on a query parameter, before anything that needs a login. `Integer` raises `ArgumentError` or `TypeError`, neither of which is a `Rsk::Urror`, so the error handler rendered `views/error.haml`, which prints the message together with the whole backtrace, and answered 503 for what is a bad request.

All of these reach it with no cookies at all:

```
/ranked?limit=abc     ArgumentError: invalid value for Integer(): "abc"
/ranked?offset[]=1    TypeError: can't convert Array into Integer
/responses            TypeError: can't convert nil into Integer
/triple?id=           ArgumentError: invalid value for Integer(): ""
/ranked?q[]=a         NoMethodError on Array#strip
```

So anyone could read absolute paths, gem versions and the internal call chain off the page, and each request also filed a Sentry event.

The conversions go through `number`, which the POST routes already use, so a bad value gives a flash message. `params[:q]` is read as a string, so an array-shaped search cannot reach `strip` either.

`test_shows_no_backtrace_on_bad_input` states this requirement already, but only covers two POST routes that were correct; the new test walks the ten GET cases above.

Opened as a draft: it conflicts with #456, which introduces `objects/paging.rb` for the same routes. I will rebase and take it out of draft once that one is merged or closed.

Closes #497
