### PR TITLE
#498: give every cookie the path it is meant to have

### DIFF
--- a/0rsk.rb
+++ b/0rsk.rb
@@ -97,14 +97,14 @@ end
 
 post '/projects/select' do
   pid = params[:id]
-  response.set_cookie('0rsk-project', pid)
+  response.set_cookie('0rsk-project', value: pid, path: '/')
   flash('/ranked', "Project ##{pid} selected")
 end
 
 post '/projects/create' do
   title = params[:title]
   pid = projects.add(title)
-  response.set_cookie('0rsk-project', pid.to_s)
+  response.set_cookie('0rsk-project', value: pid.to_s, path: '/')
   flash('/ranked', "A new project ##{pid} selected")
 end
 
@@ -295,7 +295,7 @@ module Rsk::App
     id = request.cookies['0rsk-project']
     flash('/projects', 'Pick up a project to work with, or create a new one') unless id
     unless projects.exists?(id)
-      response.delete_cookie('0rsk-project')
+      response.delete_cookie('0rsk-project', path: '/')
       flash('/projects', 'Pick up a new project')
     end
     id

--- a/front/front_login.rb
+++ b/front/front_login.rb
@@ -9,7 +9,7 @@ before '/*' do
   end
   @locals = { http_start: Time.now, ver: Rsk::VERSION, login_link: settings.glogin.login_uri, request_ip: request.ip }
   if params[:glogin] && ENV['RACK_ENV'] != 'production'
-    response.set_cookie('glogin', params[:glogin])
+    response.set_cookie('glogin', value: params[:glogin], path: '/')
   end
   if request.cookies['glogin']
     begin
@@ -19,7 +19,7 @@ before '/*' do
         context
       ).to_user
     rescue GLogin::Codec::DecodingError
-      response.delete_cookie('glogin')
+      response.delete_cookie('glogin', path: '/')
     end
   end
   @locals[:tasks_count] = tasks.count if @locals[:user]
@@ -29,21 +29,23 @@ get '/github-callback' do
   code = params[:code]
   error(400) if code.nil?
   response.set_cookie(
-    :glogin, GLogin::Cookie::Open.new(
+    :glogin,
+    value: GLogin::Cookie::Open.new(
       settings.glogin.user(code),
       settings.config['github']['encryption_secret'],
       context
-    ).to_s
+    ).to_s,
+    path: '/'
   )
   flash('/', 'You have been logged in')
 end
 
 get '/logout' do
-  response.delete_cookie('glogin')
+  response.delete_cookie('glogin', path: '/')
   flash('/', 'You have been logged out')
 end
 
 post '/logout' do
-  response.delete_cookie('glogin')
+  response.delete_cookie('glogin', path: '/')
   flash('/', 'You have been logged out')
 end

--- a/front/front_misc.rb
+++ b/front/front_misc.rb
@@ -61,10 +61,10 @@ module Rsk::Misc
     out[:local_assigns] = out
     if request.cookies['flash_msg']
       out[:flash_msg] = request.cookies['flash_msg']
-      response.delete_cookie('flash_msg')
+      response.delete_cookie('flash_msg', path: '/')
     end
     out[:flash_color] = request.cookies['flash_color'] || 'darkgreen'
-    response.delete_cookie('flash_color')
+    response.delete_cookie('flash_color', path: '/')
     out
   end
 
@@ -75,8 +75,8 @@ module Rsk::Misc
   end
 
   def flash(uri, msg = '', color: 'darkgreen')
-    response.set_cookie('flash_msg', msg)
-    response.set_cookie('flash_color', color)
+    response.set_cookie('flash_msg', value: msg, path: '/')
+    response.set_cookie('flash_color', value: color, path: '/')
     redirect(uri)
   end
 end

--- a/test/test_cookie_path.rb
+++ b/test/test_cookie_path.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require 'rack/test'
+require 'securerandom'
+require_relative 'test__helper'
+
+require_relative '../0rsk'
+
+class Rsk::CookiePathTest < TestCase
+  include Rack::Test::Methods
+
+  def app
+    Sinatra::Application
+  end
+
+  def test_scopes_every_cookie_to_the_whole_site
+    login = "u#{SecureRandom.hex(8)}"
+    set_cookie("glogin=#{login}")
+    post("/projects/select?id=#{Rsk::Projects.new(test_pgsql, login).add("p#{SecureRandom.hex(8)}")}")
+    assert_includes([302, 303], last_response.status, last_response.body)
+    cookies = Array(last_response.headers['set-cookie']).flat_map { |h| h.split("\n") }
+    refute_empty(cookies, last_response.headers.to_s)
+    cookies.each do |cookie|
+      assert_includes(cookie.downcase, 'path=/', "a cookie without a path is scoped to the route: #{cookie}")
+    end
+  end
+end


### PR DESCRIPTION
None of the six `set_cookie` calls passed a `path`, and Rack only writes `path=` when it is given. Per RFC 6265 a cookie with no path gets a default of the request URI minus its last segment, so each cookie was scoped to wherever it happened to be set:

- `POST /projects/select` set `0rsk-project` under `/projects`, then redirected to `/ranked`, which does not path-match, so the browser did not send it. `Rsk::App#pid` saw nothing and bounced the user back to `/projects`. Picking a project could not take effect.
- `POST /triple/save` set the flash under `/triple` and redirected to `/responses`, so "the triple was saved" never appeared.
- `POST /project/5/tracker/add` set it under `/project/5/tracker`, and `merged`'s `delete_cookie` was path-less too, so the stale cookie could never be cleared.
- `/logout` deleted `glogin` under `/`, but the cookie had been set under whatever path the callback used, so the deletion did not always match it.

Every cookie is written and deleted with `path: '/'` now:

```
["0rsk-project=1203; path=/", "flash_msg=Project+%231203+selected; path=/", "flash_color=darkgreen; path=/"]
```

The suite could not see this, because `Rack::Test`'s jar is filled directly by the `login` helper, which installs cookies for all paths. The new test reads the `Set-Cookie` headers instead.

Worth knowing about the order: #475 and #476 touch the same `set_cookie` calls in `front/front_login.rb`, adding `HttpOnly`, `SameSite` and the test-only parameter. Whichever of the three lands first, I will rebase the others.

Closes #498

Opened as a draft: it conflicts with #558, which changes the same file. I will rebase and take it out of draft once that one is merged or closed.
