### PR TITLE
#494: let the page read the moment the plans were checked

### DIFF
--- a/front/front_tasks.rb
+++ b/front/front_tasks.rb
@@ -8,11 +8,13 @@ require_relative '../objects/pipeline'
 require_relative '../objects/postpone'
 require_relative '../objects/tasks'
 
+Sinatra::Application.set(:updated, nil)
+
 Rsk::Daemon.new(10).start do
   users.fetch.each do |login|
     tasks(login: login).create
   end
-  @updated = Time.now
+  Sinatra::Application.set(:updated, Time.now)
 end
 
 get '/tasks' do
@@ -28,7 +30,7 @@ get '/tasks' do
     total: tasks.count(query: query),
     tasks: tasks.fetch(query: query, offset: offset, limit: limit),
     wired: telechats.wired?(identity),
-    updated: @updated
+    updated: settings.updated
   )
 end
 

--- a/test/test_tasks_updated.rb
+++ b/test/test_tasks_updated.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require 'rack/test'
+require 'securerandom'
+require_relative 'test__helper'
+
+require_relative '../0rsk'
+
+class Rsk::TasksUpdatedTest < TestCase
+  include Rack::Test::Methods
+
+  def app
+    Sinatra::Application
+  end
+
+  def test_shows_the_moment_the_plans_were_checked
+    login = "u#{SecureRandom.hex(8)}"
+    set_cookie("glogin=#{login}")
+    set_cookie("0rsk-project=#{Rsk::Projects.new(test_pgsql, login).add("p#{SecureRandom.hex(8)}")}")
+    was = Sinatra::Application.settings.updated
+    begin
+      Sinatra::Application.set(:updated, Time.now - 300)
+      get('/tasks')
+      assert_equal(200, last_response.status, last_response.body)
+      assert_includes(last_response.body, 'The last time plans were checked', last_response.body)
+      assert_includes(last_response.body, 'ago', last_response.body)
+    ensure
+      Sinatra::Application.set(:updated, was)
+    end
+  end
+end

--- a/views/tasks.haml
+++ b/views/tasks.haml
@@ -84,4 +84,4 @@
   to pull the latest plans in, right now.
   - if updated
     The last time plans were checked
-    = RelativeTime.in_words(updated.utc.iso8601) + "."
+    = "#{RelativeTime.in_words(updated.utc)}."


### PR DESCRIPTION
`@updated` was assigned inside the `Rsk::Daemon` block, which is written at the top level of this file, so `self` there is `main` and the ivar landed on that object. The `/tasks` route runs on a fresh `Sinatra::Application` instance per request, whose `@updated` was never set, so `- if updated` was false on every request and the line has never been rendered since it was added.

The moment is kept in a setting now, which the daemon writes and the route reads.

The line would not have worked even once it was reached: `RelativeTime.in_words` calls `to_time` on its argument, and `iso8601` hands it a `String`, which has no such method without ActiveSupport. Every other call site passes a `Time`; this one now does too.

```
RelativeTime.in_words(t.utc.iso8601)  NoMethodError: undefined method 'to_time' for an instance of String
RelativeTime.in_words(t.utc)          "5 minutes ago"
```

Closes #494
