### PR TITLE
#507: give the image a compiler and keep the local state out

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.bundle/
+.git/
+coverage/
+target/
+vendor/
+config.yml

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
 .bundle/
 .git/
 coverage/

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 
 FROM ruby:4.0-slim
 
-RUN apt-get update && apt-get install -y postgresql-client libpq-dev && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y build-essential postgresql-client libpq-dev && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,9 @@
 
 FROM ruby:4.0-slim
 
-RUN apt-get update && apt-get install -y build-essential postgresql-client libpq-dev && rm -rf /var/lib/apt/lists/*
+RUN apt-get update \
+  && apt-get install -y build-essential libyaml-dev postgresql-client libpq-dev \
+  && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 


### PR DESCRIPTION
`ruby:4.0-slim` ships no compiler, and `Gemfile.lock` pins several gems that have no precompiled build for that platform, so `bundle install` could not finish and the image has never been built.

Adding `build-essential` alone is not enough: the next failure is `psych`, which needs the libyaml headers.

```
without build-essential: nio4r    extconf failed
with it, without libyaml-dev: psych    yaml.h not found
with both: image builds, and psych and nio4r load inside it
```

There is no `.dockerignore`, so `COPY . .` carried in whatever the developer had locally. Two of those matter: `target/pgsql-config.yml`, which `0rsk.rb` prefers over `DATABASE_URL`, so the container silently ignored the address compose gives it and dialled 127.0.0.1 inside itself, and `.bundle/config`, which is copied after `bundle install` has already run and points `bundle exec` at a `vendor/bundle` built for another Ruby. Both files exist in a checkout where the tests have been run, so that was the ordinary outcome.

Verified by building the image, not by reading: `docker build` now exits 0 and `require "psych"; require "nio4r"` succeeds inside it.

Closes #507
