### PR TITLE
#516: refuse to run with a login cookie that is not encrypted

### DIFF
--- a/0rsk.rb
+++ b/0rsk.rb
@@ -33,9 +33,16 @@ configure do
   set :haml, format: :xhtml, escape_html: false
   config = { 'github' => { 'client_id' => '?', 'client_secret' => '?', 'encryption_secret' => '' }, 'sentry' => '' }
   cfg = File.join(File.dirname(__FILE__), 'config.yml')
-  if File.exist?(cfg)
-    loaded = YAML.safe_load(File.open(cfg))
-    config.merge!(loaded) if loaded.is_a?(Hash)
+  if File.file?(cfg)
+    loaded = YAML.safe_load_file(cfg)
+    if loaded.is_a?(Hash)
+      config.merge!(loaded) do |_key, ours, theirs|
+        ours.is_a?(Hash) && theirs.is_a?(Hash) ? ours.merge(theirs) : theirs
+      end
+    end
+  end
+  if ENV['RACK_ENV'] != 'test' && config['github']['encryption_secret'].to_s.empty?
+    raise(Rsk::Urror, 'The github.encryption_secret is empty, so a login cookie would be taken as plain text')
   end
   if config['sentry'] && !config['sentry'].empty?
     Sentry.init do |c|


### PR DESCRIPTION
The default config carries an empty `encryption_secret`, and the README documents running without `config.yml`, so a deploy that forgets to mount the file runs with it. `GLogin::Codec#decrypt` has an explicit branch for an empty secret and returns the text as it is, and `Cookie::Closed#to_user` then also skips the context check, so the cookie is taken at face value:

```
GLogin::Cookie::Closed.new('victim-login', '', 'any context').to_user
=> {"id" => "victim-login", "login" => nil, "avatar_url" => nil}
```

So `GET /ranked` with `Cookie: glogin=victim-login` is that user, with no credentials at all. The app boots normally and GitHub login appears to work; it just never validates anything.

It refuses to start with an empty secret now, outside the test environment, where the suite logs in with a plain cookie on purpose.

`config.merge!(loaded)` was also shallow, so a `config.yml` that sets `github` with only the two client fields dropped the secret entirely and left it `nil`, which makes `Cookie::Closed` raise on every request from a logged-in user:

```
shallow merge: {"client_id"=>"a", "client_secret"=>"b"}
deep merge:    {"client_id"=>"a", "client_secret"=>"b", "encryption_secret"=>"keep"}
```

`File.exist?` became `File.file?` in passing, because a bind mount that points at a missing file leaves a directory there, and `YAML.safe_load` on a directory raises `Errno::EISDIR`.

Closes #516
