### PR TITLE
#541: make a month a month and a year a year

### DIFF
--- a/objects/pipeline.rb
+++ b/objects/pipeline.rb
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
+require 'date'
 require 'time'
 
 class Rsk::Pipeline
@@ -36,6 +37,7 @@ class Rsk::Pipeline
   private
 
   def deadline(completed, schedule)
+    day = completed.to_date
     case schedule
     when 'daily'
       completed + (24 * 60 * 60)
@@ -44,11 +46,11 @@ class Rsk::Pipeline
     when 'biweekly'
       completed + (14 * 24 * 60 * 60)
     when 'monthly'
-      completed + (30 * 24 * 60 * 60)
+      completed + (((day >> 1) - day) * 24 * 60 * 60)
     when 'quarterly'
-      completed + (3 * 30 * 24 * 60 * 60)
+      completed + (((day >> 3) - day) * 24 * 60 * 60)
     when 'annually'
-      completed + (12 * 30 * 24 * 60 * 60)
+      completed + (((day >> 12) - day) * 24 * 60 * 60)
     when /^[0-9]{2}-[0-9]{2}-[0-9]{4}$/
       Time.parse(schedule)
     else

--- a/test/test_pipeline.rb
+++ b/test/test_pipeline.rb
@@ -42,6 +42,24 @@ class Rsk::PipelineTest < TestCase
     )
   end
 
+  def test_calculates_calendar_deadlines
+    pipeline = Rsk::Pipeline.new(test_pgsql, "cal#{SecureRandom.hex(8)}")
+    completed = Time.parse('2024-01-31 10:00:00 UTC')
+    {
+      'daily' => '2024-02-01 10:00:00 UTC',
+      'weekly' => '2024-02-07 10:00:00 UTC',
+      'monthly' => '2024-02-29 10:00:00 UTC',
+      'quarterly' => '2024-04-30 10:00:00 UTC',
+      'annually' => '2025-01-31 10:00:00 UTC'
+    }.each do |schedule, expected|
+      assert_equal(
+        Time.parse(expected),
+        pipeline.__send__(:deadline, completed, schedule),
+        "Wrong deadline for '#{schedule}'"
+      )
+    end
+  end
+
   private
 
   def planned(project, plans, weight)


### PR DESCRIPTION
Closes #541.

`deadline` turned the three calendar schedules into fixed spans: a month was 30 days, a quarter 90, a year 360. None of them is the period its word promises, and because the next deadline is measured from the completion of the previous one, the error accumulates. An annual review came due five or six days early every year, so after six cycles it was a month early.

They are now real calendar steps, taken with `Date#>>`, which keeps the day of the month and clamps it to the end of a shorter one. That is what `monthly` has to mean for a plan completed on the 31st: from 31 January it lands on 29 February in a leap year, not on 2 March.

The shift is applied as a difference in whole days added to the original `Time`, so the time of day survives untouched and no `DateTime` is involved.

`daily`, `weekly` and `biweekly` are left alone, because a day and a week really are fixed spans. The explicit-date branch is untouched too.

### Verification

`deadline` had no test of its own before this; the three `test_schedule_*` tests in `test_plans.rb` only assert that the schedule word is stored. The new test pins all five relative schedules from a deliberately awkward starting point, 31 January in a leap year.

Reverting the arithmetic while keeping the test:

```
test_calculates_calendar_deadlines  FAIL
  Wrong deadline for 'monthly'.
  Expected: 2024-02-29 10:00:00 UTC
    Actual: 2024-03-01 10:00:00 UTC
123 tests, 1 failures
```

With the change, the suite is green on ruby 3.3 and 4.0, and so is the rest of the fork's CI.