### PR TITLE
#500: cascade tracker deletion with its project

### DIFF
--- a/liquibase/2019/018-tracker-cascade-delete.xml
+++ b/liquibase/2019/018-tracker-cascade-delete.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+* SPDX-License-Identifier: MIT
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd" logicalFilePath="001-initial-schema.xml">
+  <changeSet id="018" author="yegor256">
+    <sql>
+      ALTER TABLE tracker
+      DROP CONSTRAINT tracker_project_fkey,
+      ADD CONSTRAINT tracker_project_fkey
+        FOREIGN KEY (project)
+        REFERENCES project(id)
+        ON DELETE CASCADE;
+    </sql>
+  </changeSet>
+</databaseChangeLog>

--- a/test/test_projects_delete_tracker.rb
+++ b/test/test_projects_delete_tracker.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../objects/projects'
+require_relative '../objects/rsk'
+require_relative '../objects/trackers'
+require_relative 'test__helper'
+
+class Rsk::ProjectsDeleteTrackerTest < TestCase
+  def test_deletes_project_that_has_tracker
+    projects = Rsk::Projects.new(test_pgsql, "u#{SecureRandom.hex(8)}")
+    pid = projects.add("t#{SecureRandom.hex(8)}")
+    Rsk::Trackers.new(test_pgsql, pid).add("yegor256/#{SecureRandom.hex(8)}", SecureRandom.hex(8))
+    projects.delete(pid)
+    assert_empty(test_pgsql.exec('SELECT id FROM project WHERE id = $1', [pid]).to_a)
+  end
+end


### PR DESCRIPTION
The `tracker.project` foreign key was the only reference to `project(id)` without
`ON DELETE CASCADE`, so a project with a tracker could not be deleted at all.

Closes #500
