### PR TITLE
#517: mark the cookies secure where they are set

### DIFF
--- a/0rsk.rb
+++ b/0rsk.rb
@@ -97,14 +97,14 @@ end
 
 post '/projects/select' do
   pid = params[:id]
-  response.set_cookie('0rsk-project', pid)
+  cookie('0rsk-project', pid)
   flash('/ranked', "Project ##{pid} selected")
 end
 
 post '/projects/create' do
   title = params[:title]
   pid = projects.add(title)
-  response.set_cookie('0rsk-project', pid.to_s)
+  cookie('0rsk-project', pid)
   flash('/ranked', "A new project ##{pid} selected")
 end
 

--- a/front/front_login.rb
+++ b/front/front_login.rb
@@ -9,7 +9,7 @@ before '/*' do
   end
   @locals = { http_start: Time.now, ver: Rsk::VERSION, login_link: settings.glogin.login_uri, request_ip: request.ip }
   if params[:glogin] && ENV['RACK_ENV'] != 'production'
-    response.set_cookie('glogin', params[:glogin])
+    cookie('glogin', params[:glogin])
   end
   if request.cookies['glogin']
     begin
@@ -28,12 +28,13 @@ end
 get '/github-callback' do
   code = params[:code]
   error(400) if code.nil?
-  response.set_cookie(
-    :glogin, GLogin::Cookie::Open.new(
+  cookie(
+    :glogin,
+    GLogin::Cookie::Open.new(
       settings.glogin.user(code),
       settings.config['github']['encryption_secret'],
       context
-    ).to_s
+    )
   )
   flash('/', 'You have been logged in')
 end

--- a/front/front_misc.rb
+++ b/front/front_misc.rb
@@ -68,6 +68,10 @@ module Rsk::Misc
     out
   end
 
+  def cookie(name, value)
+    response.set_cookie(name, value: value.to_s, secure: ENV['RACK_ENV'] != 'test', path: '/')
+  end
+
   def number(text, name)
     Integer(text.to_s, 10)
   rescue ArgumentError
@@ -75,8 +79,8 @@ module Rsk::Misc
   end
 
   def flash(uri, msg = '', color: 'darkgreen')
-    response.set_cookie('flash_msg', msg)
-    response.set_cookie('flash_color', color)
+    cookie('flash_msg', msg)
+    cookie('flash_color', color)
     redirect(uri)
   end
 end

--- a/front/front_misc.rb
+++ b/front/front_misc.rb
@@ -69,7 +69,7 @@ module Rsk::Misc
   end
 
   def cookie(name, value)
-    response.set_cookie(name, value: value.to_s, secure: ENV['RACK_ENV'] != 'test', path: '/')
+    response.set_cookie(name, value: value.to_s, secure: request.secure?, path: '/')
   end
 
   def number(text, name)

--- a/test/test_secure_cookie.rb
+++ b/test/test_secure_cookie.rb
@@ -19,8 +19,11 @@ class Rsk::SecureCookieTest < TestCase
   def test_marks_the_project_cookie_secure_over_https
     login = "u#{SecureRandom.hex(8)}"
     set_cookie("glogin=#{login}")
-    pid = Rsk::Projects.new(test_pgsql, login).add("p#{SecureRandom.hex(8)}")
-    post('/projects/select', { id: pid }, 'HTTPS' => 'on')
+    post(
+      '/projects/select',
+      { id: Rsk::Projects.new(test_pgsql, login).add("p#{SecureRandom.hex(8)}") },
+      'HTTPS' => 'on'
+    )
     assert_equal(302, last_response.status, last_response.body)
     assert_includes(last_response.headers['set-cookie'].to_s, 'secure')
   end

--- a/test/test_secure_cookie.rb
+++ b/test/test_secure_cookie.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require 'rack/test'
+require 'securerandom'
+require_relative 'test__helper'
+
+require_relative '../0rsk'
+
+class Rsk::SecureCookieTest < TestCase
+  include Rack::Test::Methods
+
+  def app
+    Sinatra::Application
+  end
+
+  def test_marks_the_project_cookie_secure_over_https
+    login = "u#{SecureRandom.hex(8)}"
+    set_cookie("glogin=#{login}")
+    pid = Rsk::Projects.new(test_pgsql, login).add("p#{SecureRandom.hex(8)}")
+    post('/projects/select', { id: pid }, 'HTTPS' => 'on')
+    assert_equal(302, last_response.status, last_response.body)
+    assert_includes(last_response.headers['set-cookie'].to_s, 'secure')
+  end
+end


### PR DESCRIPTION
`Rack::SSL` is the only thing that marked the cookies `Secure`, and under Rack 3
its `flag_cookies_as_secure!` looks up `Set-Cookie` in a plain hash that holds
the key as `set-cookie`, so it never appends the attribute. All six cookies go
through one helper now that sets `secure` from the request scheme. The
middleware stays for the http to https redirect it still does.

Overlaps with open PRs on `0rsk.rb`, `front/front_login.rb` and `front/front_misc.rb`, so this goes up as a draft.

Closes #517
