### PR TITLE
#538: keep the daemon alive and off the boot path

### DIFF
--- a/objects/daemon.rb
+++ b/objects/daemon.rb
@@ -12,12 +12,12 @@ class Rsk::Daemon
   end
 
   def start
-    sleep(1)
     Thread.start do
       loop do
         begin
           yield
-        rescue StandardError => e
+        rescue Exception => e # rubocop:disable Lint/RescueException
+          raise if e.is_a?(SystemExit) || e.is_a?(Interrupt) || e.is_a?(SignalException)
           Sentry.capture_exception(e)
         end
         sleep(@minutes * 60)

--- a/test/test_daemon_survives.rb
+++ b/test/test_daemon_survives.rb
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
+require 'benchmark'
 require_relative '../objects/daemon'
 require_relative 'test__helper'
 
@@ -24,8 +25,6 @@ class Rsk::DaemonSurvivesTest < Minitest::Test
   end
 
   def test_starts_without_delaying_the_caller
-    started = Time.now
-    Rsk::Daemon.new(0.001).start { nil }.kill
-    assert_operator(Time.now - started, :<, 0.5)
+    assert_operator(Benchmark.realtime { Rsk::Daemon.new(0.001).start { nil }.kill }, :<, 0.5)
   end
 end

--- a/test/test_daemon_survives.rb
+++ b/test/test_daemon_survives.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../objects/daemon'
+require_relative 'test__helper'
+
+class Rsk::DaemonSurvivesTest < Minitest::Test
+  def test_survives_an_error_outside_standard_error
+    counter = 0
+    d =
+      Rsk::Daemon.new(0.001).start do
+        counter += 1
+        raise(NotImplementedError, 'this is not a StandardError') if counter == 1
+      end
+    begin
+      sleep(0.5)
+      assert_operator(counter, :>, 1)
+      assert_predicate(d, :alive?)
+    ensure
+      d.kill
+    end
+  end
+
+  def test_starts_without_delaying_the_caller
+    started = Time.now
+    Rsk::Daemon.new(0.001).start { nil }.kill
+    assert_operator(Time.now - started, :<, 0.5)
+  end
+end

--- a/test/test_daemon_survives.rb
+++ b/test/test_daemon_survives.rb
@@ -3,7 +3,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
-require 'benchmark'
+require 'timeout'
 require_relative '../objects/daemon'
 require_relative 'test__helper'
 
@@ -25,6 +25,8 @@ class Rsk::DaemonSurvivesTest < Minitest::Test
   end
 
   def test_starts_without_delaying_the_caller
-    assert_operator(Benchmark.realtime { Rsk::Daemon.new(0.001).start { nil }.kill }, :<, 0.5)
+    Timeout.timeout(0.5) do
+      assert_instance_of(Thread, Rsk::Daemon.new(0.001).start { nil }.tap(&:kill))
+    end
   end
 end


### PR DESCRIPTION
The `sleep(1)` ran on the caller's thread while the app was being required, so
four daemons added four seconds to every boot. The rescue only covered
`StandardError`, so anything outside it killed the thread with nothing
reported, and nothing watched the thread afterwards. The delay is gone, and the
rescue is broad enough that the loop cannot end on its own any more, with
`SystemExit`, `Interrupt` and `SignalException` passed on so shutdown still
works.

Closes #538
