### PR TITLE
#539: run the daemons in their own process type

### DIFF
--- a/0rsk.rb
+++ b/0rsk.rb
@@ -21,6 +21,7 @@ require 'telebot'
 require 'time'
 require 'yaml'
 require_relative 'objects/limits'
+require_relative 'objects/role'
 require_relative 'objects/urror'
 require_relative 'version'
 
@@ -31,6 +32,7 @@ end
 
 configure do
   set :haml, format: :xhtml, escape_html: false
+  set :role, Rsk::Role.new
   config = { 'github' => { 'client_id' => '?', 'client_secret' => '?', 'encryption_secret' => '' }, 'sentry' => '' }
   cfg = File.join(File.dirname(__FILE__), 'config.yml')
   if File.exist?(cfg)

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
-web: bundle exec ruby 0rsk.rb -p $PORT
+web: RSK_ROLE=web bundle exec ruby 0rsk.rb -p $PORT
+daemons: RSK_ROLE=daemons bundle exec ruby 0rsk.rb -p $PORT

--- a/front/front_tasks.rb
+++ b/front/front_tasks.rb
@@ -8,11 +8,13 @@ require_relative '../objects/pipeline'
 require_relative '../objects/postpone'
 require_relative '../objects/tasks'
 
-Rsk::Daemon.new(10).start do
-  users.fetch.each do |login|
-    tasks(login: login).create
+if settings.role.daemons?
+  Rsk::Daemon.new(10).start do
+    users.fetch.each do |login|
+      tasks(login: login).create
+    end
+    @updated = Time.now
   end
-  @updated = Time.now
 end
 
 get '/tasks' do

--- a/front/front_telegram.rb
+++ b/front/front_telegram.rb
@@ -214,7 +214,7 @@ module Rsk::Telegram
 end
 Object.include(Rsk::Telegram)
 
-if settings.config['telegram']
+if settings.config['telegram'] && settings.role.daemons?
   Rsk::Daemon.new.start do
     Telebot::Bot.new(settings.config['telegram']['token']).run do |_, message|
       chat = message.chat.id
@@ -232,13 +232,13 @@ if settings.config['telegram']
   end
 end
 
-if settings.config['telegram']
+if settings.config['telegram'] && settings.role.daemons?
   Rsk::Daemon.new(10).start do
     broadcast
   end
 end
 
-if settings.config['telegram']
+if settings.config['telegram'] && settings.role.daemons?
   Rsk::Daemon.new(1440).start do
     alone
   end

--- a/objects/role.rb
+++ b/objects/role.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'rsk'
+
+class Rsk::Role
+  def initialize(name = ENV.fetch('RSK_ROLE', nil))
+    @name = name
+  end
+
+  def daemons?
+    @name.nil? || @name == 'daemons'
+  end
+end

--- a/test/test_role.rb
+++ b/test/test_role.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../objects/role'
+require_relative 'test__helper'
+
+class Rsk::RoleTest < Minitest::Test
+  def test_web_dyno_runs_no_daemons
+    refute_predicate(Rsk::Role.new('web'), :daemons?)
+  end
+
+  def test_daemons_dyno_runs_them
+    assert_predicate(Rsk::Role.new('daemons'), :daemons?)
+  end
+
+  def test_runs_them_when_the_role_is_not_set
+    assert_predicate(Rsk::Role.new(nil), :daemons?)
+  end
+end


### PR DESCRIPTION
The daemons started at require time in the web process, and `Procfile` declared
only `web`, so every dyno ran its own copy: two `getUpdates` pollers on one bot
token, reminders sent twice, and `Rsk::Tasks#create` multiplied by the dyno
count. They are gated on a role now, and `Procfile` has a `daemons` process
type to scale to one. With no `RSK_ROLE` set, which is the local and test case,
they run as before.

Overlaps with open PRs on `0rsk.rb`, `front/front_tasks.rb` and `front/front_telegram.rb`, so this goes up as a draft.

Closes #539
